### PR TITLE
ci: ignore generated files on review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,7 @@
 reviews:
   profile: "assertive"
   request_changes_workflow: true
-  path_instructions:
-    - path: "**.{freezed.dart,g.dart,mocks.dart}"
-      instructions: Please ignore generated files in reviews
+  path_filters:
+    - "!**/*.freezed.dart"
+    - "!**/*.g.dart"
+    - "!**/*.mocks.dart"


### PR DESCRIPTION
Ignore generated files on reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to improve how generated files are excluded from review processes. No impact on user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->