### PR TITLE
revert: "ci: pass project and patch checks if no coverage found"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,12 +7,10 @@ coverage:
       default:
         target: auto
         base: auto
-        if_not_found: "success"
     patch:
       default:
         target: auto
         base: auto
-        if_not_found: "success"
 
 component_management:
   individual_components:


### PR DESCRIPTION
Reverts Peetee06/flutter-testing-concepts#35, because the configuration does not actually lead to codecov checks to pass if no coverage is uploaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated code coverage configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->