### PR TITLE
ci: Add Codecov carryforward flags configuration

### DIFF
--- a/.github/actions/upload-test-results/action.yaml
+++ b/.github/actions/upload-test-results/action.yaml
@@ -26,6 +26,7 @@ runs:
         files: ${{ inputs.coverage-files }}
         disable_search: true
         name: ${{ inputs.package-name }}-coverage
+        flags: ${{ inputs.package-name }}
         fail_ci_if_error: true
         report_type: coverage
 
@@ -36,5 +37,6 @@ runs:
         files: ${{ inputs.test-results-files }}
         disable_search: true
         name: ${{ inputs.package-name }}-tests
+        flags: ${{ inputs.package-name }}
         fail_ci_if_error: true
         report_type: test_results

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 comment:
   layout: "header, diff, components"
+  show_carryforward_flags: true
 
 coverage:
   status:
@@ -11,6 +12,20 @@ coverage:
       default:
         target: auto
         base: auto
+
+flags:
+  riverpod_app:
+    paths:
+      - riverpod_app/**/*
+    carryforward: true
+  bloc_app:
+    paths:
+      - bloc_app/**/*
+    carryforward: true
+  common:
+    paths:
+      - common/**/*
+    carryforward: true
 
 component_management:
   individual_components:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This PR adds carryforward flags configuration to Codecov to ensure code coverage is preserved when no new reports are uploaded in a PR.

- Added carryforward flags to codecov.yml for each package (riverpod_app, bloc_app, common)
- Set `carryforward: true` so coverage data persists when no new reports are uploaded
- Added `show_carryforward_flags: true` to display carried forward coverage in PR comments
- Updated GitHub action to use the flags parameter for proper tagging of coverage uploads

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated test results upload process to dynamically set flags for each package.
  - Enhanced Codecov configuration to display carryforward flags and defined new flags for improved coverage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->