### PR TITLE
feat: implement concept feature for Riverpod app (issue #47)

### DIFF
--- a/riverpod_app/lib/features/concept/concept_notifier.dart
+++ b/riverpod_app/lib/features/concept/concept_notifier.dart
@@ -1,0 +1,18 @@
+import 'package:common/common.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:riverpod_app/data/repositories/concepts_repository.dart';
+
+part 'concept_notifier.g.dart';
+
+@riverpod
+class ConceptNotifier extends _$ConceptNotifier {
+  @override
+  Future<Concept> build(String id) async {
+    final repository = ref.watch(conceptsRepositoryProvider);
+    final concepts = await repository.getConcepts();
+    return concepts.firstWhere(
+      (concept) => concept.id == id,
+      orElse: () => throw Exception('Concept not found'),
+    );
+  }
+}

--- a/riverpod_app/lib/features/concept/concept_notifier.g.dart
+++ b/riverpod_app/lib/features/concept/concept_notifier.g.dart
@@ -1,0 +1,176 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'concept_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$conceptNotifierHash() => r'28f14a871e6e434ee6a125ccb3a0f274c8b63594';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$ConceptNotifier
+    extends BuildlessAutoDisposeAsyncNotifier<Concept> {
+  late final String id;
+
+  FutureOr<Concept> build(
+    String id,
+  );
+}
+
+/// See also [ConceptNotifier].
+@ProviderFor(ConceptNotifier)
+const conceptNotifierProvider = ConceptNotifierFamily();
+
+/// See also [ConceptNotifier].
+class ConceptNotifierFamily extends Family<AsyncValue<Concept>> {
+  /// See also [ConceptNotifier].
+  const ConceptNotifierFamily();
+
+  /// See also [ConceptNotifier].
+  ConceptNotifierProvider call(
+    String id,
+  ) {
+    return ConceptNotifierProvider(
+      id,
+    );
+  }
+
+  @override
+  ConceptNotifierProvider getProviderOverride(
+    covariant ConceptNotifierProvider provider,
+  ) {
+    return call(
+      provider.id,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'conceptNotifierProvider';
+}
+
+/// See also [ConceptNotifier].
+class ConceptNotifierProvider
+    extends AutoDisposeAsyncNotifierProviderImpl<ConceptNotifier, Concept> {
+  /// See also [ConceptNotifier].
+  ConceptNotifierProvider(
+    String id,
+  ) : this._internal(
+          () => ConceptNotifier()..id = id,
+          from: conceptNotifierProvider,
+          name: r'conceptNotifierProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$conceptNotifierHash,
+          dependencies: ConceptNotifierFamily._dependencies,
+          allTransitiveDependencies:
+              ConceptNotifierFamily._allTransitiveDependencies,
+          id: id,
+        );
+
+  ConceptNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.id,
+  }) : super.internal();
+
+  final String id;
+
+  @override
+  FutureOr<Concept> runNotifierBuild(
+    covariant ConceptNotifier notifier,
+  ) {
+    return notifier.build(
+      id,
+    );
+  }
+
+  @override
+  Override overrideWith(ConceptNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: ConceptNotifierProvider._internal(
+        () => create()..id = id,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        id: id,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<ConceptNotifier, Concept>
+      createElement() {
+    return _ConceptNotifierProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is ConceptNotifierProvider && other.id == id;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, id.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin ConceptNotifierRef on AutoDisposeAsyncNotifierProviderRef<Concept> {
+  /// The parameter `id` of this provider.
+  String get id;
+}
+
+class _ConceptNotifierProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<ConceptNotifier, Concept>
+    with ConceptNotifierRef {
+  _ConceptNotifierProviderElement(super.provider);
+
+  @override
+  String get id => (origin as ConceptNotifierProvider).id;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/riverpod_app/lib/features/concept/concept_route.dart
+++ b/riverpod_app/lib/features/concept/concept_route.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:riverpod_app/features/concept/view/concept_view.dart';
+
+class ConceptRoute extends GoRouteData {
+  const ConceptRoute({required this.id});
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return ConceptView(id: id);
+  }
+}

--- a/riverpod_app/lib/features/concept/view/concept_view.dart
+++ b/riverpod_app/lib/features/concept/view/concept_view.dart
@@ -1,0 +1,63 @@
+import 'package:common/common.dart' hide Localizations;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_app/features/concept/concept_notifier.dart';
+import 'package:riverpod_app/features/concept/view/widgets/sections_view.dart';
+
+class ConceptView extends StatelessWidget {
+  const ConceptView({required this.id, super.key});
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: _ConceptAppBar(id: id),
+      body: _ConceptBody(id: id),
+    );
+  }
+}
+
+class _ConceptAppBar extends ConsumerWidget implements PreferredSizeWidget {
+  const _ConceptAppBar({required this.id});
+  final String id;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final concept = ref.watch(conceptNotifierProvider(id));
+    return switch (concept) {
+      AsyncData(:final value) => AppBar(
+          title: Text(
+            value.title.localizedTo(Localizations.localeOf(context)),
+          ),
+        ),
+      _ => AppBar(),
+    };
+  }
+}
+
+class _ConceptBody extends ConsumerWidget {
+  const _ConceptBody({required this.id});
+  final String id;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final concept = ref.watch(conceptNotifierProvider(id));
+    return switch (concept) {
+      AsyncData(:final value) => SectionsView(
+          id: value.id,
+          sections: value.sections,
+          hasChallenges: value.challengeIds.isNotEmpty,
+        ),
+      AsyncError(:final error) => Center(
+          child: Text(error.toString()),
+        ),
+      _ => const Center(
+          child: CircularProgressIndicator(),
+        ),
+    };
+  }
+}

--- a/riverpod_app/lib/features/concept/view/widgets/section_view.dart
+++ b/riverpod_app/lib/features/concept/view/widgets/section_view.dart
@@ -1,0 +1,38 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:common/common.dart' hide Localizations;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_app/data/services/cache_manager_provider.dart';
+
+class SectionView extends ConsumerWidget {
+  const SectionView({required this.section, super.key});
+  final Section section;
+
+  static const _verticalSpacing = 20.0;
+  static const _imageSize = 200.0;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final cacheManager = ref.watch(cacheManagerProvider);
+    return ListView.separated(
+      separatorBuilder: (context, index) =>
+          const SizedBox(height: _verticalSpacing),
+      itemCount: section.content.length,
+      itemBuilder: (context, index) {
+        final component = section.content[index];
+        return switch (component) {
+          TextComponent(:final text) => Text(
+              text.localizedTo(Localizations.localeOf(context)),
+            ),
+          ImageComponent(:final imageUri) => CachedNetworkImage(
+              imageUrl: imageUri.toString(),
+              fit: BoxFit.scaleDown,
+              width: _imageSize,
+              height: _imageSize,
+              cacheManager: cacheManager,
+            ),
+        };
+      },
+    );
+  }
+}

--- a/riverpod_app/lib/features/concept/view/widgets/sections_view.dart
+++ b/riverpod_app/lib/features/concept/view/widgets/sections_view.dart
@@ -1,0 +1,178 @@
+import 'package:common/common.dart';
+import 'package:flutter/material.dart';
+import 'package:riverpod_app/features/concept/view/widgets/section_view.dart';
+import 'package:riverpod_app/l10n/l10n.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+class SectionsView extends StatefulWidget {
+  const SectionsView({
+    required this.id,
+    required this.sections,
+    required this.hasChallenges,
+    super.key,
+  });
+
+  final String id;
+  final List<Section> sections;
+  final bool hasChallenges;
+
+  static const Key backButtonKey = Key('sectionsViewBackButton');
+  static const Key forwardButtonKey = Key('sectionsViewForwardButton');
+
+  @override
+  State<SectionsView> createState() => _SectionsViewState();
+}
+
+class _SectionsViewState extends State<SectionsView> {
+  late final PageController _pageController;
+  bool _canNavigateBack = false;
+  late bool _canNavigateForward;
+
+  @override
+  void initState() {
+    super.initState();
+    _canNavigateForward = widget.sections.length > 1 || widget.hasChallenges;
+    _pageController = PageController()..addListener(_updateNavigationButtons);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _updateNavigationButtons() {
+    setState(() {
+      final isNotFirstPage = _pageController.page != 0;
+      final isNotLastPage = _pageController.page != widget.sections.length - 1;
+      _canNavigateBack = isNotFirstPage;
+      _canNavigateForward = isNotLastPage || widget.hasChallenges;
+    });
+  }
+
+  void _navigateBack() {
+    _pageController.previousPage(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+    );
+  }
+
+  void _navigateForward() {
+    final hasNoSections = widget.sections.isEmpty;
+    if (hasNoSections || _pageController.page == widget.sections.length - 1) {
+      // TODO(Peetee06): Implement navigation to challenges route
+      // ChallengesRoute(id: widget.id).go(context);
+    } else {
+      _pageController.nextPage(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8),
+      child: Stack(
+        alignment: Alignment.bottomCenter,
+        children: [
+          Column(
+            children: [
+              _SectionAndChallengesIndicator(
+                controller: _pageController,
+                sectionCount: widget.sections.length,
+                hasChallenges: widget.hasChallenges,
+              ),
+              Expanded(
+                child: widget.sections.isEmpty
+                    ? Center(child: Text(context.l10n.sectionsEmpty))
+                    : PageView.builder(
+                        controller: _pageController,
+                        physics: const NeverScrollableScrollPhysics(),
+                        itemCount: widget.sections.length,
+                        itemBuilder: (context, index) {
+                          final section = widget.sections[index];
+                          return SectionView(section: section);
+                        },
+                      ),
+              ),
+            ],
+          ),
+          if (_canNavigateBack || _canNavigateForward)
+            Row(
+              children: [
+                if (_canNavigateBack)
+                  _BackButton(
+                    key: SectionsView.backButtonKey,
+                    onPressed: _navigateBack,
+                  ),
+                const Spacer(),
+                if (_canNavigateForward)
+                  _ForwardButton(
+                    key: SectionsView.forwardButtonKey,
+                    onPressed: _navigateForward,
+                  ),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BackButton extends StatelessWidget {
+  const _BackButton({required this.onPressed, super.key});
+  final VoidCallback onPressed;
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      onPressed: onPressed,
+      icon: const Icon(Icons.arrow_back),
+      label: const Text('Back'),
+    );
+  }
+}
+
+class _ForwardButton extends StatelessWidget {
+  const _ForwardButton({required this.onPressed, super.key});
+  final VoidCallback onPressed;
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: onPressed,
+      label: const Text('Next'),
+      iconAlignment: IconAlignment.end,
+      icon: const Icon(Icons.arrow_forward),
+    );
+  }
+}
+
+class _SectionAndChallengesIndicator extends StatelessWidget {
+  const _SectionAndChallengesIndicator({
+    required this.controller,
+    required this.sectionCount,
+    required this.hasChallenges,
+  });
+  final PageController controller;
+  final int sectionCount;
+  final bool hasChallenges;
+  @override
+  Widget build(BuildContext context) => Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (sectionCount > 0)
+            SmoothPageIndicator(
+              controller: controller,
+              count: sectionCount,
+            ),
+          if (sectionCount > 0 && hasChallenges) const SizedBox(width: 6),
+          if (hasChallenges)
+            const Icon(
+              Icons.task_outlined,
+              size: 20,
+            ),
+        ],
+      );
+}

--- a/riverpod_app/lib/features/concepts/concepts_route.dart
+++ b/riverpod_app/lib/features/concepts/concepts_route.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:riverpod_app/features/concept/concept_route.dart';
 import 'package:riverpod_app/features/concepts/view/concepts_view.dart';
 
 part 'concepts_route.g.dart';
@@ -7,6 +8,12 @@ part 'concepts_route.g.dart';
 @TypedGoRoute<ConceptsRoute>(
   path: '/concepts',
   name: 'concepts',
+  routes: [
+    TypedGoRoute<ConceptRoute>(
+      path: ':id',
+      name: 'concept',
+    ),
+  ],
 )
 class ConceptsRoute extends GoRouteData {
   const ConceptsRoute();

--- a/riverpod_app/lib/features/concepts/concepts_route.g.dart
+++ b/riverpod_app/lib/features/concepts/concepts_route.g.dart
@@ -14,6 +14,13 @@ RouteBase get $conceptsRoute => GoRouteData.$route(
       path: '/concepts',
       name: 'concepts',
       factory: $ConceptsRouteExtension._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: ':id',
+          name: 'concept',
+          factory: $ConceptRouteExtension._fromState,
+        ),
+      ],
     );
 
 extension $ConceptsRouteExtension on ConceptsRoute {
@@ -21,6 +28,25 @@ extension $ConceptsRouteExtension on ConceptsRoute {
 
   String get location => GoRouteData.$location(
         '/concepts',
+      );
+
+  void go(BuildContext context) => context.go(location);
+
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  void replace(BuildContext context) => context.replace(location);
+}
+
+extension $ConceptRouteExtension on ConceptRoute {
+  static ConceptRoute _fromState(GoRouterState state) => ConceptRoute(
+        id: state.pathParameters['id']!,
+      );
+
+  String get location => GoRouteData.$location(
+        '/concepts/${Uri.encodeComponent(id)}',
       );
 
   void go(BuildContext context) => context.go(location);

--- a/riverpod_app/lib/features/concepts/view/concepts_view.dart
+++ b/riverpod_app/lib/features/concepts/view/concepts_view.dart
@@ -1,7 +1,9 @@
 import 'package:common/common.dart' hide Localizations;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_app/features/concept/concept_route.dart';
 import 'package:riverpod_app/features/concepts/concepts_notifier.dart';
+import 'package:riverpod_app/features/concepts/concepts_route.dart';
 import 'package:riverpod_app/l10n/l10n.dart';
 
 class ConceptsView extends StatelessWidget {
@@ -46,6 +48,7 @@ class ConceptsContent extends ConsumerWidget {
                           .conceptsChallenges(concept.challengeIds.length),
                     ),
                   ),
+                  onTap: () => ConceptRoute(id: concept.id).go(context),
                 );
               },
             ),

--- a/riverpod_app/lib/l10n/arb/app_de.arb
+++ b/riverpod_app/lib/l10n/arb/app_de.arb
@@ -29,5 +29,9 @@
     "conceptsEmpty": "Keine Konzepte gefunden",
     "@conceptsEmpty": {
         "description": "Text, der angezeigt wird, wenn keine Konzepte gefunden werden"
+    },
+    "sectionsEmpty": "Keine Abschnitte",
+    "@sectionsEmpty": {
+        "description": "Text, der angezeigt wird, wenn es keine Abschnitte in einem Konzept gibt"
     }
 }

--- a/riverpod_app/lib/l10n/arb/app_en.arb
+++ b/riverpod_app/lib/l10n/arb/app_en.arb
@@ -29,5 +29,9 @@
     "conceptsEmpty": "No concepts found",
     "@conceptsEmpty": {
         "description": "Text shown when there are no concepts"
+    },
+    "sectionsEmpty": "No sections",
+    "@sectionsEmpty": {
+        "description": "Text shown when there are no sections in a concept"
     }
 }

--- a/riverpod_app/pubspec.lock
+++ b/riverpod_app/pubspec.lock
@@ -113,6 +113,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.9.5"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -476,6 +500,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.5"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -665,6 +697,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  smooth_page_indicator:
+    dependency: "direct main"
+    description:
+      name: smooth_page_indicator
+      sha256: b21ebb8bc39cf72d11c7cfd809162a48c3800668ced1c9da3aade13a32cf6c1c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   source_gen:
     dependency: transitive
     description:

--- a/riverpod_app/pubspec.yaml
+++ b/riverpod_app/pubspec.yaml
@@ -7,12 +7,13 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
+  cached_network_image: ^3.4.1
   common:
     path: ../common
   dio: ^5.8.0+1
   flutter:
     sdk: flutter
-  flutter_cache_manager: ^3.3.1
+  flutter_cache_manager: ^3.4.1
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^2.6.1
@@ -22,6 +23,7 @@ dependencies:
   json_annotation: ^4.9.0
   retrofit: ^4.4.2
   riverpod_annotation: ^2.6.1
+  smooth_page_indicator: ^1.2.1
 
 dev_dependencies:
   analyzer: 7.3.0

--- a/riverpod_app/test/features/concept/concept_notifier_test.dart
+++ b/riverpod_app/test/features/concept/concept_notifier_test.dart
@@ -1,0 +1,77 @@
+import 'package:common/common.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:riverpod_app/data/repositories/concepts_repository.dart';
+import 'package:riverpod_app/features/concept/concept_notifier.dart';
+
+import '../../mocks.mocks.dart';
+
+void main() {
+  group('ConceptNotifier', () {
+    late MockConceptsRepository mockRepository;
+    final concept = Concept(
+      id: '1',
+      title: {'en': 'Test Concept', 'de': 'Test Konzept'},
+      sections: [
+        Section(
+          content: [
+            const ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
+            ContentComponent.image(
+              imageUri: Uri.parse('https://example.com/image.jpg'),
+            ),
+          ],
+        ),
+      ],
+      challengeIds: ['1', '2'],
+    );
+
+    setUp(() {
+      mockRepository = MockConceptsRepository();
+    });
+
+    Future<Concept> getConcept({
+      required String id,
+    }) async {
+      final container = ProviderContainer(
+        overrides: [
+          conceptsRepositoryProvider.overrideWithValue(mockRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container.read(conceptNotifierProvider(id).future);
+    }
+
+    test('returns a concept for a valid id', () async {
+      when(mockRepository.getConcepts()).thenAnswer((_) async => [concept]);
+      final result = await getConcept(id: '1');
+      expect(result, concept);
+      verify(mockRepository.getConcepts()).called(1);
+    });
+
+    test('throws error for non-existent concept', () async {
+      when(mockRepository.getConcepts()).thenAnswer((_) async => []);
+      expect(
+        () => getConcept(id: 'nonexistent'),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'error',
+            contains('Concept not found'),
+          ),
+        ),
+      );
+      verify(mockRepository.getConcepts()).called(1);
+    });
+
+    test('throws error when repository throws', () async {
+      final error = Exception('Test error');
+      when(mockRepository.getConcepts()).thenThrow(error);
+      expect(
+        () => getConcept(id: '1'),
+        throwsA(error),
+      );
+      verify(mockRepository.getConcepts()).called(1);
+    });
+  });
+}

--- a/riverpod_app/test/features/concept/concept_route_test.dart
+++ b/riverpod_app/test/features/concept/concept_route_test.dart
@@ -1,0 +1,46 @@
+import 'package:common/common.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:riverpod_app/features/concept/concept_notifier.dart';
+import 'package:riverpod_app/features/concept/concept_route.dart';
+import 'package:riverpod_app/features/concept/view/concept_view.dart';
+import 'package:riverpod_app/features/concepts/concepts_route.dart';
+
+import '../../helpers/pump_app.dart';
+import 'fake_concept_notifier.dart';
+
+void main() {
+  group(ConceptRoute, () {
+    testWidgets('renders ConceptView', (tester) async {
+      final concept = Concept(
+        id: 'test-id',
+        title: {'en': 'Test Concept', 'de': 'Test Konzept'},
+        sections: [
+          Section(
+            content: [
+              const ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
+              ContentComponent.image(
+                imageUri: Uri.parse('https://example.com/image.jpg'),
+              ),
+            ],
+          ),
+        ],
+        challengeIds: ['1', '2'],
+      );
+      final router = GoRouter(
+        initialLocation: const ConceptRoute(id: 'test-id').location,
+        routes: $appRoutes,
+      );
+      await tester.pumpAppWithRouter(
+        router: router,
+        overrides: [
+          conceptNotifierProvider(concept.id).overrideWith(
+            () => FakeConceptNotifier(concept: concept),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(ConceptView), findsOneWidget);
+    });
+  });
+}

--- a/riverpod_app/test/features/concept/fake_concept_notifier.dart
+++ b/riverpod_app/test/features/concept/fake_concept_notifier.dart
@@ -1,0 +1,28 @@
+import 'package:common/common.dart';
+import 'package:riverpod_app/features/concept/concept_notifier.dart';
+
+import '../../helpers/future_behavior.dart';
+
+class FakeConceptNotifier extends ConceptNotifier {
+  FakeConceptNotifier({
+    required this.concept,
+    this.behavior,
+  });
+
+  Concept concept;
+  FutureBehavior? behavior;
+
+  @override
+  Future<Concept> build(String id) async {
+    await behavior?.simulate();
+    return concept;
+  }
+
+  void updateMock({
+    Concept? concept,
+    FutureBehavior? behavior,
+  }) {
+    this.concept = concept ?? this.concept;
+    this.behavior = behavior;
+  }
+}

--- a/riverpod_app/test/features/concept/fake_concept_notifier.dart
+++ b/riverpod_app/test/features/concept/fake_concept_notifier.dart
@@ -14,6 +14,9 @@ class FakeConceptNotifier extends ConceptNotifier {
 
   @override
   Future<Concept> build(String id) async {
+    if (concept.id != id) {
+      throw AssertionError('Concept id mismatch');
+    }
     await behavior?.simulate();
     return concept;
   }

--- a/riverpod_app/test/features/concept/fake_concept_notifier.dart
+++ b/riverpod_app/test/features/concept/fake_concept_notifier.dart
@@ -18,7 +18,7 @@ class FakeConceptNotifier extends ConceptNotifier {
     return concept;
   }
 
-  void updateMock({
+  void updateFake({
     Concept? concept,
     FutureBehavior? behavior,
   }) {

--- a/riverpod_app/test/features/concept/view/concept_view_test.dart
+++ b/riverpod_app/test/features/concept/view/concept_view_test.dart
@@ -1,0 +1,116 @@
+import 'package:common/common.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_app/features/concept/concept_notifier.dart';
+import 'package:riverpod_app/features/concept/view/concept_view.dart';
+import 'package:riverpod_app/features/concept/view/widgets/sections_view.dart';
+
+import '../../../helpers/helpers.dart';
+import '../../concept/fake_concept_notifier.dart';
+
+void main() {
+  const testConcept = Concept(
+    id: '1',
+    title: {'en': 'Test Concept', 'de': 'Test Konzept'},
+    sections: [
+      Section(
+        content: [
+          ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
+        ],
+      ),
+    ],
+    challengeIds: [],
+  );
+
+  Future<void> pumpTestWidget(
+    WidgetTester tester, {
+    required Concept concept,
+    FutureBehavior? behavior,
+    Locale locale = const Locale('de'),
+  }) async {
+    await tester.pumpApp(
+      widget: ConceptView(id: concept.id),
+      overrides: [
+        conceptNotifierProvider(concept.id).overrideWith(
+          () => FakeConceptNotifier(concept: concept, behavior: behavior),
+        ),
+      ],
+      locale: locale,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('ConceptView', () {
+    testWidgets('renders AppBar in loaded state', (tester) async {
+      await pumpTestWidget(
+        tester,
+        concept: testConcept,
+      );
+      expect(find.byType(AppBar), findsOneWidget);
+      expect(find.text('Test Konzept'), findsOneWidget);
+    });
+
+    testWidgets('renders progress indicator while loading', (tester) async {
+      await tester.pumpApp(
+        widget: ConceptView(id: testConcept.id),
+        overrides: [
+          conceptNotifierProvider(testConcept.id).overrideWith(
+            () => FakeConceptNotifier(
+              concept: testConcept,
+              behavior: FutureBehavior(loading: true),
+            ),
+          ),
+        ],
+      );
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(AppBar), findsOneWidget);
+    });
+
+    testWidgets('renders error message when error occurs', (tester) async {
+      final error = Exception('error');
+      await tester.pumpApp(
+        widget: ConceptView(id: testConcept.id),
+        overrides: [
+          conceptNotifierProvider(testConcept.id).overrideWith(
+            () => FakeConceptNotifier(
+              concept: testConcept,
+              behavior: FutureBehavior(error: error),
+            ),
+          ),
+        ],
+      );
+      await tester.pump();
+      expect(find.textContaining('error'), findsOneWidget);
+      expect(find.byType(AppBar), findsOneWidget);
+    });
+
+    testWidgets('passes sections to SectionsView', (tester) async {
+      await pumpTestWidget(tester, concept: testConcept);
+      final sectionsView =
+          tester.widget<SectionsView>(find.byType(SectionsView));
+      expect(sectionsView.sections, testConcept.sections);
+    });
+
+    testWidgets('passes false to SectionsView when no challenges',
+        (tester) async {
+      await pumpTestWidget(tester, concept: testConcept);
+      final sectionsView =
+          tester.widget<SectionsView>(find.byType(SectionsView));
+      expect(sectionsView.hasChallenges, false);
+    });
+
+    testWidgets('passes true to SectionsView when challenges', (tester) async {
+      const conceptWithChallenges = Concept(
+        id: '2',
+        title: {'en': 'Test Concept', 'de': 'Test Konzept'},
+        sections: [],
+        challengeIds: ['1'],
+      );
+      await pumpTestWidget(tester, concept: conceptWithChallenges);
+      final sectionsView =
+          tester.widget<SectionsView>(find.byType(SectionsView));
+      expect(sectionsView.hasChallenges, true);
+    });
+  });
+}

--- a/riverpod_app/test/features/concept/view/section_view_test.dart
+++ b/riverpod_app/test/features/concept/view/section_view_test.dart
@@ -62,6 +62,8 @@ void main() {
         ),
       );
       expect(find.byType(CachedNetworkImage), findsOneWidget);
+      final cachedImage = tester.widget<CachedNetworkImage>(find.byType(CachedNetworkImage));
+      expect(cachedImage.imageUrl, 'https://example.com/image.jpg');
     });
 
     testWidgets('renders multiple components', (tester) async {

--- a/riverpod_app/test/features/concept/view/section_view_test.dart
+++ b/riverpod_app/test/features/concept/view/section_view_test.dart
@@ -1,0 +1,82 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:common/common.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:riverpod_app/data/services/cache_manager_provider.dart';
+import 'package:riverpod_app/features/concept/view/widgets/section_view.dart';
+
+import '../../../helpers/pump_app.dart';
+import '../../../mocks.mocks.dart';
+
+void main() {
+  late MockBaseCacheManager cacheManager;
+
+  setUp(() {
+    cacheManager = MockBaseCacheManager();
+    when(
+      cacheManager.getFileStream(
+        any,
+        key: anyNamed('key'),
+        headers: anyNamed('headers'),
+        withProgress: anyNamed('withProgress'),
+      ),
+    ).thenAnswer((_) => const Stream<FileResponse>.empty());
+  });
+
+  group(SectionView, () {
+    testWidgets('renders text component', (tester) async {
+      await tester.pumpApp(
+        widget: const SectionView(
+          section: Section(
+            content: [
+              ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
+            ],
+          ),
+        ),
+        overrides: [
+          cacheManagerProvider.overrideWith((ref) => cacheManager),
+        ],
+      );
+      expect(find.text('Hallo'), findsOneWidget);
+    });
+
+    testWidgets('renders image component', (tester) async {
+      await tester.pumpApp(
+        widget: SectionView(
+          section: Section(
+            content: [
+              ContentComponent.image(
+                imageUri: Uri.parse('https://example.com/image.jpg'),
+              ),
+            ],
+          ),
+        ),
+        overrides: [
+          cacheManagerProvider.overrideWith((ref) => cacheManager),
+        ],
+      );
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+    });
+
+    testWidgets('renders multiple components', (tester) async {
+      await tester.pumpApp(
+        widget: SectionView(
+          section: Section(
+            content: [
+              const ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
+              ContentComponent.image(
+                imageUri: Uri.parse('https://example.com/image.jpg'),
+              ),
+            ],
+          ),
+        ),
+        overrides: [
+          cacheManagerProvider.overrideWith((ref) => cacheManager),
+        ],
+      );
+      expect(find.text('Hallo'), findsOneWidget);
+      expect(find.byType(CachedNetworkImage), findsOneWidget);
+    });
+  });
+}

--- a/riverpod_app/test/features/concept/view/section_view_test.dart
+++ b/riverpod_app/test/features/concept/view/section_view_test.dart
@@ -62,7 +62,9 @@ void main() {
         ),
       );
       expect(find.byType(CachedNetworkImage), findsOneWidget);
-      final cachedImage = tester.widget<CachedNetworkImage>(find.byType(CachedNetworkImage));
+      final cachedImage = tester.widget<CachedNetworkImage>(
+        find.byType(CachedNetworkImage),
+      );
       expect(cachedImage.imageUrl, 'https://example.com/image.jpg');
     });
 

--- a/riverpod_app/test/features/concept/view/section_view_test.dart
+++ b/riverpod_app/test/features/concept/view/section_view_test.dart
@@ -80,5 +80,14 @@ void main() {
       expect(find.text('Hallo'), findsOneWidget);
       expect(find.byType(CachedNetworkImage), findsOneWidget);
     });
+
+    testWidgets('handles empty content gracefully', (tester) async {
+      await pumpSectionView(
+        tester,
+        section: const Section(content: []),
+      );
+
+      expect(find.byType(SectionView), findsOneWidget);
+    });
   });
 }

--- a/riverpod_app/test/features/concept/view/section_view_test.dart
+++ b/riverpod_app/test/features/concept/view/section_view_test.dart
@@ -24,57 +24,59 @@ void main() {
     ).thenAnswer((_) => const Stream<FileResponse>.empty());
   });
 
+  Future<void> pumpSectionView(
+    WidgetTester tester, {
+    required Section section,
+  }) async {
+    await tester.pumpApp(
+      widget: SectionView(section: section),
+      overrides: [
+        cacheManagerProvider.overrideWith((_) => cacheManager),
+      ],
+    );
+  }
+
   group(SectionView, () {
     testWidgets('renders text component', (tester) async {
-      await tester.pumpApp(
-        widget: const SectionView(
-          section: Section(
-            content: [
-              ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
-            ],
-          ),
+      await pumpSectionView(
+        tester,
+        section: const Section(
+          content: [
+            ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
+          ],
         ),
-        overrides: [
-          cacheManagerProvider.overrideWith((ref) => cacheManager),
-        ],
       );
+      // default locale is de
       expect(find.text('Hallo'), findsOneWidget);
     });
 
     testWidgets('renders image component', (tester) async {
-      await tester.pumpApp(
-        widget: SectionView(
-          section: Section(
-            content: [
-              ContentComponent.image(
-                imageUri: Uri.parse('https://example.com/image.jpg'),
-              ),
-            ],
-          ),
+      await pumpSectionView(
+        tester,
+        section: Section(
+          content: [
+            ContentComponent.image(
+              imageUri: Uri.parse('https://example.com/image.jpg'),
+            ),
+          ],
         ),
-        overrides: [
-          cacheManagerProvider.overrideWith((ref) => cacheManager),
-        ],
       );
       expect(find.byType(CachedNetworkImage), findsOneWidget);
     });
 
     testWidgets('renders multiple components', (tester) async {
-      await tester.pumpApp(
-        widget: SectionView(
-          section: Section(
-            content: [
-              const ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
-              ContentComponent.image(
-                imageUri: Uri.parse('https://example.com/image.jpg'),
-              ),
-            ],
-          ),
+      await pumpSectionView(
+        tester,
+        section: Section(
+          content: [
+            const ContentComponent.text(text: {'en': 'Hello', 'de': 'Hallo'}),
+            ContentComponent.image(
+              imageUri: Uri.parse('https://example.com/image.jpg'),
+            ),
+          ],
         ),
-        overrides: [
-          cacheManagerProvider.overrideWith((ref) => cacheManager),
-        ],
       );
+      // default locale is de
       expect(find.text('Hallo'), findsOneWidget);
       expect(find.byType(CachedNetworkImage), findsOneWidget);
     });

--- a/riverpod_app/test/features/concept/view/sections_view_test.dart
+++ b/riverpod_app/test/features/concept/view/sections_view_test.dart
@@ -1,0 +1,182 @@
+import 'package:common/common.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_app/features/concept/view/widgets/section_view.dart';
+import 'package:riverpod_app/features/concept/view/widgets/sections_view.dart';
+import 'package:riverpod_app/l10n/l10n.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+import '../../../helpers/pump_app.dart';
+
+void main() {
+  group(SectionsView, () {
+    Future<void> pumpTestWidget(
+      WidgetTester tester, {
+      required List<Section> sections,
+      bool hasChallenges = false,
+      Locale locale = const Locale('de'),
+    }) async {
+      await tester.pumpApp(
+        locale: locale,
+        widget: SectionsView(
+          id: 'id',
+          sections: sections,
+          hasChallenges: hasChallenges,
+        ),
+      );
+    }
+
+    testWidgets('renders no sections text when sections is empty',
+        (tester) async {
+      await pumpTestWidget(tester, sections: []);
+      final context = tester.element(find.byType(SectionsView));
+      expect(find.text(context.l10n.sectionsEmpty), findsOneWidget);
+    });
+
+    testWidgets('renders SectionView and passes current section',
+        (tester) async {
+      final sections = [
+        const Section(
+          content: [
+            ContentComponent.text(text: {'en': 'A'}),
+          ],
+        ),
+        const Section(
+          content: [
+            ContentComponent.text(text: {'en': 'B'}),
+          ],
+        ),
+      ];
+      await pumpTestWidget(tester, sections: sections);
+      expect(find.byType(SectionView), findsOneWidget);
+      final sectionView = tester.widget<SectionView>(find.byType(SectionView));
+      expect(sectionView.section, sections.first);
+      await tester.tap(find.byKey(SectionsView.forwardButtonKey));
+      await tester.pumpAndSettle();
+      final updatedSectionView =
+          tester.widget<SectionView>(find.byType(SectionView));
+      expect(updatedSectionView.section, sections.last);
+    });
+
+    testWidgets('renders smooth page indicator', (tester) async {
+      final sections = [const Section(content: []), const Section(content: [])];
+      await pumpTestWidget(tester, sections: sections);
+      expect(find.byType(SmoothPageIndicator), findsOneWidget);
+      await tester.tap(find.byKey(SectionsView.forwardButtonKey));
+      await tester.pumpAndSettle();
+      expect(find.byType(SmoothPageIndicator), findsOneWidget);
+    });
+
+    testWidgets('hides smooth page indicator when sections is empty',
+        (tester) async {
+      await pumpTestWidget(tester, sections: []);
+      expect(find.byType(SmoothPageIndicator), findsNothing);
+    });
+
+    testWidgets('renders challenge icon when hasChallenges is true',
+        (tester) async {
+      await pumpTestWidget(tester, sections: [], hasChallenges: true);
+      expect(find.byIcon(Icons.task_outlined), findsOneWidget);
+    });
+
+    testWidgets('hides challenge icon by default', (tester) async {
+      await pumpTestWidget(tester, sections: []);
+      expect(find.byIcon(Icons.task_outlined), findsNothing);
+    });
+
+    testWidgets('hides challenge icon when hasChallenges is false',
+        (tester) async {
+      await pumpTestWidget(tester, sections: []);
+      expect(find.byIcon(Icons.task_outlined), findsNothing);
+    });
+
+    testWidgets(
+        'has separator when hasChallenges is true and sections is not empty',
+        (tester) async {
+      await pumpTestWidget(
+        tester,
+        sections: [const Section(content: [])],
+        hasChallenges: true,
+      );
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.children.any((child) => child is SizedBox), true);
+    });
+
+    testWidgets(
+        'hides separator when hasChallenges is false and sections is not empty',
+        (tester) async {
+      await pumpTestWidget(tester, sections: [const Section(content: [])]);
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.children.any((child) => child is SizedBox), false);
+    });
+
+    testWidgets(
+        'hides separator when hasChallenges is true and sections is empty',
+        (tester) async {
+      await pumpTestWidget(tester, sections: [], hasChallenges: true);
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.children.any((child) => child is SizedBox), false);
+    });
+
+    testWidgets(
+        'hides separator when hasChallenges is false and sections is empty',
+        (tester) async {
+      await pumpTestWidget(tester, sections: []);
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.children.any((child) => child is SizedBox), false);
+    });
+
+    testWidgets('back button is hidden on first section', (tester) async {
+      await pumpTestWidget(
+        tester,
+        sections: [const Section(content: []), const Section(content: [])],
+      );
+      expect(find.byKey(SectionsView.backButtonKey), findsNothing);
+      expect(find.byKey(SectionsView.forwardButtonKey), findsOneWidget);
+    });
+
+    testWidgets('forward button is hidden on last section when no challenges',
+        (tester) async {
+      await pumpTestWidget(
+        tester,
+        sections: [const Section(content: []), const Section(content: [])],
+      );
+      await tester.tap(find.byKey(SectionsView.forwardButtonKey));
+      await tester.pumpAndSettle();
+      expect(find.byKey(SectionsView.forwardButtonKey), findsNothing);
+    });
+
+    testWidgets('back button is visible after navigating forward',
+        (tester) async {
+      await pumpTestWidget(
+        tester,
+        sections: [const Section(content: []), const Section(content: [])],
+      );
+      await tester.tap(find.byKey(SectionsView.forwardButtonKey));
+      await tester.pumpAndSettle();
+      expect(find.byKey(SectionsView.backButtonKey), findsOneWidget);
+    });
+
+    testWidgets('forward button is visible after navigating back',
+        (tester) async {
+      await pumpTestWidget(
+        tester,
+        sections: [const Section(content: []), const Section(content: [])],
+      );
+      await tester.tap(find.byKey(SectionsView.forwardButtonKey));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(SectionsView.backButtonKey));
+      await tester.pumpAndSettle();
+      expect(find.byKey(SectionsView.forwardButtonKey), findsOneWidget);
+    });
+
+    testWidgets(
+      'navigates to challenges route (skipped)',
+      (tester) async {
+        // ignore: lines_longer_than_80_chars
+        // TODO(Peetee06): Implement this test once the challenges route is available.
+      },
+      skip: true,
+    );
+  });
+}

--- a/riverpod_app/test/helpers/pump_app.dart
+++ b/riverpod_app/test/helpers/pump_app.dart
@@ -13,7 +13,7 @@ extension PumpApp on WidgetTester {
   Future<void> pumpApp({
     required Widget widget,
     List<Override> overrides = const [],
-    Locale? locale = _defaultLocale,
+    Locale locale = _defaultLocale,
   }) {
     return pumpWidget(
       ProviderScope(
@@ -31,7 +31,7 @@ extension PumpApp on WidgetTester {
   Future<void> pumpAppWithRouter({
     required GoRouter router,
     List<Override> overrides = const [],
-    Locale? locale = _defaultLocale,
+    Locale locale = _defaultLocale,
   }) {
     return pumpWidget(
       ProviderScope(

--- a/riverpod_app/test/mocks.dart
+++ b/riverpod_app/test/mocks.dart
@@ -1,13 +1,17 @@
 import 'package:dio/dio.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mockito/annotations.dart';
 import 'package:riverpod_app/data/repositories/concepts_repository.dart';
 import 'package:riverpod_app/data/services/rest_client.dart';
 
 @GenerateMocks([
-  Dio,
-  ResponseInterceptorHandler,
-  Response,
-  RestClient,
+  BaseCacheManager,
   ConceptsRepository,
+  Dio,
+  GoRouter,
+  Response,
+  ResponseInterceptorHandler,
+  RestClient,
 ])
 class GeneratedMocks {}

--- a/riverpod_app/test/mocks.mocks.dart
+++ b/riverpod_app/test/mocks.mocks.dart
@@ -3,22 +3,37 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i10;
+import 'dart:async' as _i18;
+import 'dart:typed_data' as _i26;
 
-import 'package:common/common.dart' as _i14;
+import 'package:common/common.dart' as _i22;
 import 'package:dio/src/adapter.dart' as _i3;
-import 'package:dio/src/cancel_token.dart' as _i11;
+import 'package:dio/src/cancel_token.dart' as _i19;
 import 'package:dio/src/dio.dart' as _i7;
-import 'package:dio/src/dio_exception.dart' as _i12;
+import 'package:dio/src/dio_exception.dart' as _i20;
 import 'package:dio/src/dio_mixin.dart' as _i5;
 import 'package:dio/src/headers.dart' as _i8;
 import 'package:dio/src/options.dart' as _i2;
-import 'package:dio/src/redirect_record.dart' as _i13;
+import 'package:dio/src/redirect_record.dart' as _i21;
 import 'package:dio/src/response.dart' as _i6;
 import 'package:dio/src/transformer.dart' as _i4;
+import 'package:file/file.dart' as _i10;
+import 'package:flutter/widgets.dart' as _i13;
+import 'package:flutter_cache_manager/src/cache_managers/base_cache_manager.dart'
+    as _i24;
+import 'package:flutter_cache_manager/src/result/file_info.dart' as _i11;
+import 'package:flutter_cache_manager/src/result/file_response.dart' as _i25;
+import 'package:go_router/src/configuration.dart' as _i12;
+import 'package:go_router/src/delegate.dart' as _i14;
+import 'package:go_router/src/information_provider.dart' as _i15;
+import 'package:go_router/src/match.dart' as _i29;
+import 'package:go_router/src/parser.dart' as _i16;
+import 'package:go_router/src/router.dart' as _i27;
+import 'package:go_router/src/state.dart' as _i17;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i28;
 import 'package:riverpod_app/data/repositories/concepts_repository.dart'
-    as _i15;
+    as _i23;
 import 'package:riverpod_app/data/services/rest_client.dart' as _i9;
 
 // ignore_for_file: type=lint
@@ -93,6 +108,52 @@ class _FakeRestClient_10 extends _i1.SmartFake implements _i9.RestClient {
       : super(parent, parentInvocation);
 }
 
+class _FakeFile_11 extends _i1.SmartFake implements _i10.File {
+  _FakeFile_11(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
+class _FakeFileInfo_12 extends _i1.SmartFake implements _i11.FileInfo {
+  _FakeFileInfo_12(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
+class _FakeRouteConfiguration_13 extends _i1.SmartFake
+    implements _i12.RouteConfiguration {
+  _FakeRouteConfiguration_13(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
+class _FakeBackButtonDispatcher_14 extends _i1.SmartFake
+    implements _i13.BackButtonDispatcher {
+  _FakeBackButtonDispatcher_14(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
+class _FakeGoRouterDelegate_15 extends _i1.SmartFake
+    implements _i14.GoRouterDelegate {
+  _FakeGoRouterDelegate_15(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
+class _FakeGoRouteInformationProvider_16 extends _i1.SmartFake
+    implements _i15.GoRouteInformationProvider {
+  _FakeGoRouteInformationProvider_16(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
+class _FakeGoRouteInformationParser_17 extends _i1.SmartFake
+    implements _i16.GoRouteInformationParser {
+  _FakeGoRouteInformationParser_17(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
+class _FakeGoRouterState_18 extends _i1.SmartFake
+    implements _i17.GoRouterState {
+  _FakeGoRouterState_18(Object parent, Invocation parentInvocation)
+      : super(parent, parentInvocation);
+}
+
 /// A class which mocks [Dio].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -160,12 +221,12 @@ class MockDio extends _i1.Mock implements _i7.Dio {
       );
 
   @override
-  _i10.Future<_i6.Response<T>> head<T>(
+  _i18.Future<_i6.Response<T>> head<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -178,7 +239,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -193,14 +254,14 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> headUri<T>(
+  _i18.Future<_i6.Response<T>> headUri<T>(
     Uri? uri, {
     Object? data,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -208,7 +269,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
           [uri],
           {#data: data, #options: options, #cancelToken: cancelToken},
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -218,15 +279,15 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> get<T>(
+  _i18.Future<_i6.Response<T>> get<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
@@ -241,7 +302,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -257,14 +318,14 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> getUri<T>(
+  _i18.Future<_i6.Response<T>> getUri<T>(
     Uri? uri, {
     Object? data,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.ProgressCallback? onReceiveProgress,
   }) =>
       (super.noSuchMethod(
@@ -278,7 +339,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -293,15 +354,15 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> post<T>(
+  _i18.Future<_i6.Response<T>> post<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.ProgressCallback? onSendProgress,
     _i2.ProgressCallback? onReceiveProgress,
   }) =>
@@ -318,7 +379,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -335,14 +396,14 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> postUri<T>(
+  _i18.Future<_i6.Response<T>> postUri<T>(
     Uri? uri, {
     Object? data,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.ProgressCallback? onSendProgress,
     _i2.ProgressCallback? onReceiveProgress,
   }) =>
@@ -358,7 +419,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -374,15 +435,15 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> put<T>(
+  _i18.Future<_i6.Response<T>> put<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.ProgressCallback? onSendProgress,
     _i2.ProgressCallback? onReceiveProgress,
   }) =>
@@ -399,7 +460,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -416,14 +477,14 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> putUri<T>(
+  _i18.Future<_i6.Response<T>> putUri<T>(
     Uri? uri, {
     Object? data,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.ProgressCallback? onSendProgress,
     _i2.ProgressCallback? onReceiveProgress,
   }) =>
@@ -439,7 +500,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -455,15 +516,15 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> patch<T>(
+  _i18.Future<_i6.Response<T>> patch<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.ProgressCallback? onSendProgress,
     _i2.ProgressCallback? onReceiveProgress,
   }) =>
@@ -480,7 +541,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -497,14 +558,14 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> patchUri<T>(
+  _i18.Future<_i6.Response<T>> patchUri<T>(
     Uri? uri, {
     Object? data,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.ProgressCallback? onSendProgress,
     _i2.ProgressCallback? onReceiveProgress,
   }) =>
@@ -520,7 +581,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -536,15 +597,15 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> delete<T>(
+  _i18.Future<_i6.Response<T>> delete<T>(
     String? path, {
     Object? data,
     Map<String, dynamic>? queryParameters,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -557,7 +618,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #cancelToken: cancelToken,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -572,14 +633,14 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> deleteUri<T>(
+  _i18.Future<_i6.Response<T>> deleteUri<T>(
     Uri? uri, {
     Object? data,
     _i2.Options? options,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -587,7 +648,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
           [uri],
           {#data: data, #options: options, #cancelToken: cancelToken},
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -597,15 +658,15 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<dynamic>> download(
+  _i18.Future<_i6.Response<dynamic>> download(
     String? urlPath,
     dynamic savePath, {
     _i2.ProgressCallback? onReceiveProgress,
     Map<String, dynamic>? queryParameters,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     bool? deleteOnError = true,
     _i2.FileAccessMode? fileAccessMode = _i2.FileAccessMode.write,
     String? lengthHeader = 'content-length',
@@ -627,7 +688,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #options: options,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<dynamic>>.value(
+        returnValue: _i18.Future<_i6.Response<dynamic>>.value(
           _FakeResponse_4<dynamic>(
             this,
             Invocation.method(
@@ -646,14 +707,14 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<dynamic>>);
+      ) as _i18.Future<_i6.Response<dynamic>>);
 
   @override
-  _i10.Future<_i6.Response<dynamic>> downloadUri(
+  _i18.Future<_i6.Response<dynamic>> downloadUri(
     Uri? uri,
     dynamic savePath, {
     _i2.ProgressCallback? onReceiveProgress,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     bool? deleteOnError = true,
     _i2.FileAccessMode? fileAccessMode = _i2.FileAccessMode.write,
     String? lengthHeader = 'content-length',
@@ -674,7 +735,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #options: options,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<dynamic>>.value(
+        returnValue: _i18.Future<_i6.Response<dynamic>>.value(
           _FakeResponse_4<dynamic>(
             this,
             Invocation.method(
@@ -692,14 +753,14 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<dynamic>>);
+      ) as _i18.Future<_i6.Response<dynamic>>);
 
   @override
-  _i10.Future<_i6.Response<T>> request<T>(
+  _i18.Future<_i6.Response<T>> request<T>(
     String? url, {
     Object? data,
     Map<String, dynamic>? queryParameters,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.Options? options,
     _i2.ProgressCallback? onSendProgress,
     _i2.ProgressCallback? onReceiveProgress,
@@ -717,7 +778,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -734,13 +795,13 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> requestUri<T>(
+  _i18.Future<_i6.Response<T>> requestUri<T>(
     Uri? uri, {
     Object? data,
-    _i11.CancelToken? cancelToken,
+    _i19.CancelToken? cancelToken,
     _i2.Options? options,
     _i2.ProgressCallback? onSendProgress,
     _i2.ProgressCallback? onReceiveProgress,
@@ -757,7 +818,7 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             #onReceiveProgress: onReceiveProgress,
           },
         ),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(
@@ -773,19 +834,19 @@ class MockDio extends _i1.Mock implements _i7.Dio {
             ),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
-  _i10.Future<_i6.Response<T>> fetch<T>(_i2.RequestOptions? requestOptions) =>
+  _i18.Future<_i6.Response<T>> fetch<T>(_i2.RequestOptions? requestOptions) =>
       (super.noSuchMethod(
         Invocation.method(#fetch, [requestOptions]),
-        returnValue: _i10.Future<_i6.Response<T>>.value(
+        returnValue: _i18.Future<_i6.Response<T>>.value(
           _FakeResponse_4<T>(
             this,
             Invocation.method(#fetch, [requestOptions]),
           ),
         ),
-      ) as _i10.Future<_i6.Response<T>>);
+      ) as _i18.Future<_i6.Response<T>>);
 
   @override
   _i7.Dio clone({
@@ -823,15 +884,15 @@ class MockResponseInterceptorHandler extends _i1.Mock
   }
 
   @override
-  _i10.Future<_i5.InterceptorState<dynamic>> get future => (super.noSuchMethod(
+  _i18.Future<_i5.InterceptorState<dynamic>> get future => (super.noSuchMethod(
         Invocation.getter(#future),
-        returnValue: _i10.Future<_i5.InterceptorState<dynamic>>.value(
+        returnValue: _i18.Future<_i5.InterceptorState<dynamic>>.value(
           _FakeInterceptorState_6<dynamic>(
             this,
             Invocation.getter(#future),
           ),
         ),
-      ) as _i10.Future<_i5.InterceptorState<dynamic>>);
+      ) as _i18.Future<_i5.InterceptorState<dynamic>>);
 
   @override
   bool get isCompleted =>
@@ -852,7 +913,7 @@ class MockResponseInterceptorHandler extends _i1.Mock
 
   @override
   void reject(
-    _i12.DioException? error, [
+    _i20.DioException? error, [
     bool? callFollowingErrorInterceptor = false,
   ]) =>
       super.noSuchMethod(
@@ -926,13 +987,13 @@ class MockResponse<T> extends _i1.Mock implements _i6.Response<T> {
       );
 
   @override
-  List<_i13.RedirectRecord> get redirects => (super.noSuchMethod(
+  List<_i21.RedirectRecord> get redirects => (super.noSuchMethod(
         Invocation.getter(#redirects),
-        returnValue: <_i13.RedirectRecord>[],
-      ) as List<_i13.RedirectRecord>);
+        returnValue: <_i21.RedirectRecord>[],
+      ) as List<_i21.RedirectRecord>);
 
   @override
-  set redirects(List<_i13.RedirectRecord>? _redirects) => super.noSuchMethod(
+  set redirects(List<_i21.RedirectRecord>? _redirects) => super.noSuchMethod(
         Invocation.setter(#redirects, _redirects),
         returnValueForMissingStub: null,
       );
@@ -965,27 +1026,27 @@ class MockRestClient extends _i1.Mock implements _i9.RestClient {
   }
 
   @override
-  _i10.Future<List<_i14.Concept>> getConcepts() => (super.noSuchMethod(
+  _i18.Future<List<_i22.Concept>> getConcepts() => (super.noSuchMethod(
         Invocation.method(#getConcepts, []),
-        returnValue: _i10.Future<List<_i14.Concept>>.value(
-          <_i14.Concept>[],
+        returnValue: _i18.Future<List<_i22.Concept>>.value(
+          <_i22.Concept>[],
         ),
-      ) as _i10.Future<List<_i14.Concept>>);
+      ) as _i18.Future<List<_i22.Concept>>);
 
   @override
-  _i10.Future<List<_i14.Challenge>> getChallenges() => (super.noSuchMethod(
+  _i18.Future<List<_i22.Challenge>> getChallenges() => (super.noSuchMethod(
         Invocation.method(#getChallenges, []),
-        returnValue: _i10.Future<List<_i14.Challenge>>.value(
-          <_i14.Challenge>[],
+        returnValue: _i18.Future<List<_i22.Challenge>>.value(
+          <_i22.Challenge>[],
         ),
-      ) as _i10.Future<List<_i14.Challenge>>);
+      ) as _i18.Future<List<_i22.Challenge>>);
 }
 
 /// A class which mocks [ConceptsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockConceptsRepository extends _i1.Mock
-    implements _i15.ConceptsRepository {
+    implements _i23.ConceptsRepository {
   MockConceptsRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -1000,10 +1061,483 @@ class MockConceptsRepository extends _i1.Mock
       ) as _i9.RestClient);
 
   @override
-  _i10.Future<List<_i14.Concept>> getConcepts() => (super.noSuchMethod(
+  _i18.Future<List<_i22.Concept>> getConcepts() => (super.noSuchMethod(
         Invocation.method(#getConcepts, []),
-        returnValue: _i10.Future<List<_i14.Concept>>.value(
-          <_i14.Concept>[],
+        returnValue: _i18.Future<List<_i22.Concept>>.value(
+          <_i22.Concept>[],
         ),
-      ) as _i10.Future<List<_i14.Concept>>);
+      ) as _i18.Future<List<_i22.Concept>>);
+}
+
+/// A class which mocks [BaseCacheManager].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockBaseCacheManager extends _i1.Mock implements _i24.BaseCacheManager {
+  MockBaseCacheManager() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i18.Future<_i10.File> getSingleFile(
+    String? url, {
+    String? key,
+    Map<String, String>? headers,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getSingleFile,
+          [url],
+          {#key: key, #headers: headers},
+        ),
+        returnValue: _i18.Future<_i10.File>.value(
+          _FakeFile_11(
+            this,
+            Invocation.method(
+              #getSingleFile,
+              [url],
+              {#key: key, #headers: headers},
+            ),
+          ),
+        ),
+      ) as _i18.Future<_i10.File>);
+
+  @override
+  _i18.Stream<_i11.FileInfo> getFile(
+    String? url, {
+    String? key,
+    Map<String, String>? headers,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(#getFile, [url], {#key: key, #headers: headers}),
+        returnValue: _i18.Stream<_i11.FileInfo>.empty(),
+      ) as _i18.Stream<_i11.FileInfo>);
+
+  @override
+  _i18.Stream<_i25.FileResponse> getFileStream(
+    String? url, {
+    String? key,
+    Map<String, String>? headers,
+    bool? withProgress,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getFileStream,
+          [url],
+          {#key: key, #headers: headers, #withProgress: withProgress},
+        ),
+        returnValue: _i18.Stream<_i25.FileResponse>.empty(),
+      ) as _i18.Stream<_i25.FileResponse>);
+
+  @override
+  _i18.Future<_i11.FileInfo> downloadFile(
+    String? url, {
+    String? key,
+    Map<String, String>? authHeaders,
+    bool? force = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #downloadFile,
+          [url],
+          {#key: key, #authHeaders: authHeaders, #force: force},
+        ),
+        returnValue: _i18.Future<_i11.FileInfo>.value(
+          _FakeFileInfo_12(
+            this,
+            Invocation.method(
+              #downloadFile,
+              [url],
+              {#key: key, #authHeaders: authHeaders, #force: force},
+            ),
+          ),
+        ),
+      ) as _i18.Future<_i11.FileInfo>);
+
+  @override
+  _i18.Future<_i11.FileInfo?> getFileFromCache(
+    String? key, {
+    bool? ignoreMemCache = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getFileFromCache,
+          [key],
+          {#ignoreMemCache: ignoreMemCache},
+        ),
+        returnValue: _i18.Future<_i11.FileInfo?>.value(),
+      ) as _i18.Future<_i11.FileInfo?>);
+
+  @override
+  _i18.Future<_i11.FileInfo?> getFileFromMemory(String? key) =>
+      (super.noSuchMethod(
+        Invocation.method(#getFileFromMemory, [key]),
+        returnValue: _i18.Future<_i11.FileInfo?>.value(),
+      ) as _i18.Future<_i11.FileInfo?>);
+
+  @override
+  _i18.Future<_i10.File> putFile(
+    String? url,
+    _i26.Uint8List? fileBytes, {
+    String? key,
+    String? eTag,
+    Duration? maxAge = const Duration(days: 30),
+    String? fileExtension = 'file',
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #putFile,
+          [url, fileBytes],
+          {
+            #key: key,
+            #eTag: eTag,
+            #maxAge: maxAge,
+            #fileExtension: fileExtension,
+          },
+        ),
+        returnValue: _i18.Future<_i10.File>.value(
+          _FakeFile_11(
+            this,
+            Invocation.method(
+              #putFile,
+              [url, fileBytes],
+              {
+                #key: key,
+                #eTag: eTag,
+                #maxAge: maxAge,
+                #fileExtension: fileExtension,
+              },
+            ),
+          ),
+        ),
+      ) as _i18.Future<_i10.File>);
+
+  @override
+  _i18.Future<_i10.File> putFileStream(
+    String? url,
+    _i18.Stream<List<int>>? source, {
+    String? key,
+    String? eTag,
+    Duration? maxAge = const Duration(days: 30),
+    String? fileExtension = 'file',
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #putFileStream,
+          [url, source],
+          {
+            #key: key,
+            #eTag: eTag,
+            #maxAge: maxAge,
+            #fileExtension: fileExtension,
+          },
+        ),
+        returnValue: _i18.Future<_i10.File>.value(
+          _FakeFile_11(
+            this,
+            Invocation.method(
+              #putFileStream,
+              [url, source],
+              {
+                #key: key,
+                #eTag: eTag,
+                #maxAge: maxAge,
+                #fileExtension: fileExtension,
+              },
+            ),
+          ),
+        ),
+      ) as _i18.Future<_i10.File>);
+
+  @override
+  _i18.Future<void> removeFile(String? key) => (super.noSuchMethod(
+        Invocation.method(#removeFile, [key]),
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
+
+  @override
+  _i18.Future<void> emptyCache() => (super.noSuchMethod(
+        Invocation.method(#emptyCache, []),
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
+
+  @override
+  _i18.Future<void> dispose() => (super.noSuchMethod(
+        Invocation.method(#dispose, []),
+        returnValue: _i18.Future<void>.value(),
+        returnValueForMissingStub: _i18.Future<void>.value(),
+      ) as _i18.Future<void>);
+}
+
+/// A class which mocks [GoRouter].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockGoRouter extends _i1.Mock implements _i27.GoRouter {
+  MockGoRouter() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i12.RouteConfiguration get configuration => (super.noSuchMethod(
+        Invocation.getter(#configuration),
+        returnValue: _FakeRouteConfiguration_13(
+          this,
+          Invocation.getter(#configuration),
+        ),
+      ) as _i12.RouteConfiguration);
+
+  @override
+  set configuration(_i12.RouteConfiguration? _configuration) =>
+      super.noSuchMethod(
+        Invocation.setter(#configuration, _configuration),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i13.BackButtonDispatcher get backButtonDispatcher => (super.noSuchMethod(
+        Invocation.getter(#backButtonDispatcher),
+        returnValue: _FakeBackButtonDispatcher_14(
+          this,
+          Invocation.getter(#backButtonDispatcher),
+        ),
+      ) as _i13.BackButtonDispatcher);
+
+  @override
+  _i14.GoRouterDelegate get routerDelegate => (super.noSuchMethod(
+        Invocation.getter(#routerDelegate),
+        returnValue: _FakeGoRouterDelegate_15(
+          this,
+          Invocation.getter(#routerDelegate),
+        ),
+      ) as _i14.GoRouterDelegate);
+
+  @override
+  set routerDelegate(_i14.GoRouterDelegate? _routerDelegate) =>
+      super.noSuchMethod(
+        Invocation.setter(#routerDelegate, _routerDelegate),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i15.GoRouteInformationProvider get routeInformationProvider =>
+      (super.noSuchMethod(
+        Invocation.getter(#routeInformationProvider),
+        returnValue: _FakeGoRouteInformationProvider_16(
+          this,
+          Invocation.getter(#routeInformationProvider),
+        ),
+      ) as _i15.GoRouteInformationProvider);
+
+  @override
+  set routeInformationProvider(
+    _i15.GoRouteInformationProvider? _routeInformationProvider,
+  ) =>
+      super.noSuchMethod(
+        Invocation.setter(#routeInformationProvider, _routeInformationProvider),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i16.GoRouteInformationParser get routeInformationParser =>
+      (super.noSuchMethod(
+        Invocation.getter(#routeInformationParser),
+        returnValue: _FakeGoRouteInformationParser_17(
+          this,
+          Invocation.getter(#routeInformationParser),
+        ),
+      ) as _i16.GoRouteInformationParser);
+
+  @override
+  set routeInformationParser(
+    _i16.GoRouteInformationParser? _routeInformationParser,
+  ) =>
+      super.noSuchMethod(
+        Invocation.setter(#routeInformationParser, _routeInformationParser),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  bool get overridePlatformDefaultLocation => (super.noSuchMethod(
+        Invocation.getter(#overridePlatformDefaultLocation),
+        returnValue: false,
+      ) as bool);
+
+  @override
+  _i17.GoRouterState get state => (super.noSuchMethod(
+        Invocation.getter(#state),
+        returnValue: _FakeGoRouterState_18(this, Invocation.getter(#state)),
+      ) as _i17.GoRouterState);
+
+  @override
+  bool canPop() =>
+      (super.noSuchMethod(Invocation.method(#canPop, []), returnValue: false)
+          as bool);
+
+  @override
+  String namedLocation(
+    String? name, {
+    Map<String, String>? pathParameters = const {},
+    Map<String, dynamic>? queryParameters = const {},
+    String? fragment,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #namedLocation,
+          [name],
+          {
+            #pathParameters: pathParameters,
+            #queryParameters: queryParameters,
+            #fragment: fragment,
+          },
+        ),
+        returnValue: _i28.dummyValue<String>(
+          this,
+          Invocation.method(
+            #namedLocation,
+            [name],
+            {
+              #pathParameters: pathParameters,
+              #queryParameters: queryParameters,
+              #fragment: fragment,
+            },
+          ),
+        ),
+      ) as String);
+
+  @override
+  void go(String? location, {Object? extra}) => super.noSuchMethod(
+        Invocation.method(#go, [location], {#extra: extra}),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void restore(_i29.RouteMatchList? matchList) => super.noSuchMethod(
+        Invocation.method(#restore, [matchList]),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void goNamed(
+    String? name, {
+    Map<String, String>? pathParameters = const {},
+    Map<String, dynamic>? queryParameters = const {},
+    Object? extra,
+    String? fragment,
+  }) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #goNamed,
+          [name],
+          {
+            #pathParameters: pathParameters,
+            #queryParameters: queryParameters,
+            #extra: extra,
+            #fragment: fragment,
+          },
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i18.Future<T?> push<T extends Object?>(String? location, {Object? extra}) =>
+      (super.noSuchMethod(
+        Invocation.method(#push, [location], {#extra: extra}),
+        returnValue: _i18.Future<T?>.value(),
+      ) as _i18.Future<T?>);
+
+  @override
+  _i18.Future<T?> pushNamed<T extends Object?>(
+    String? name, {
+    Map<String, String>? pathParameters = const {},
+    Map<String, dynamic>? queryParameters = const {},
+    Object? extra,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #pushNamed,
+          [name],
+          {
+            #pathParameters: pathParameters,
+            #queryParameters: queryParameters,
+            #extra: extra,
+          },
+        ),
+        returnValue: _i18.Future<T?>.value(),
+      ) as _i18.Future<T?>);
+
+  @override
+  _i18.Future<T?> pushReplacement<T extends Object?>(
+    String? location, {
+    Object? extra,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(#pushReplacement, [location], {#extra: extra}),
+        returnValue: _i18.Future<T?>.value(),
+      ) as _i18.Future<T?>);
+
+  @override
+  _i18.Future<T?> pushReplacementNamed<T extends Object?>(
+    String? name, {
+    Map<String, String>? pathParameters = const {},
+    Map<String, dynamic>? queryParameters = const {},
+    Object? extra,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #pushReplacementNamed,
+          [name],
+          {
+            #pathParameters: pathParameters,
+            #queryParameters: queryParameters,
+            #extra: extra,
+          },
+        ),
+        returnValue: _i18.Future<T?>.value(),
+      ) as _i18.Future<T?>);
+
+  @override
+  _i18.Future<T?> replace<T>(String? location, {Object? extra}) =>
+      (super.noSuchMethod(
+        Invocation.method(#replace, [location], {#extra: extra}),
+        returnValue: _i18.Future<T?>.value(),
+      ) as _i18.Future<T?>);
+
+  @override
+  _i18.Future<T?> replaceNamed<T>(
+    String? name, {
+    Map<String, String>? pathParameters = const {},
+    Map<String, dynamic>? queryParameters = const {},
+    Object? extra,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #replaceNamed,
+          [name],
+          {
+            #pathParameters: pathParameters,
+            #queryParameters: queryParameters,
+            #extra: extra,
+          },
+        ),
+        returnValue: _i18.Future<T?>.value(),
+      ) as _i18.Future<T?>);
+
+  @override
+  void pop<T extends Object?>([T? result]) => super.noSuchMethod(
+        Invocation.method(#pop, [result]),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void refresh() => super.noSuchMethod(
+        Invocation.method(#refresh, []),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(#dispose, []),
+        returnValueForMissingStub: null,
+      );
 }


### PR DESCRIPTION
## Summary

This PR implements the new concept feature for the Riverpod app as described in issue #47. The changes include:

- Addition of the `concept` feature module with notifier, route, and views
- Updates to localization files for new concept-related strings
- Updates to the concepts feature to integrate the new concept module
- New and updated tests for concept feature and related helpers/mocks
- Dependency and configuration updates in `pubspec.yaml` and `pubspec.lock`

All changes are limited to the `riverpod_app` directory.

---

Please review the implementation and provide feedback. All code is formatted and passes static analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced detailed concept views with section navigation, localized titles, and support for both text and image content.
  - Enabled navigation from the concepts list to individual concept details.
  - Added paginated section navigation with indicators and challenge support in concept views.
  - Added routing support for concept-specific views under the concepts route.

- **Bug Fixes**
  - Improved localization by adding new messages for empty section states in English and German.

- **Tests**
  - Added comprehensive tests for concept detail views, section rendering, routing, navigation behaviors, and notifier logic.
  - Introduced test helpers and mocks to support routing and caching in tests.

- **Chores**
  - Updated dependencies and added new packages for image caching and page indicators.
  - Enforced non-nullable locale parameters in test helper methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->