### PR TITLE
docs: specify to only use analyze and format command on dart files

### DIFF
--- a/.cursor/rules/git-rules.mdc
+++ b/.cursor/rules/git-rules.mdc
@@ -16,7 +16,7 @@ Follow these rules closely when working with git and GitHub.
    - You can check for staged `.dart` files using this command:
 
      ```bash
-     git diff --name-only --staged HEAD | grep '\.dart$'
+     git diff --name-only --staged | grep '\.dart$'
      ```
 
 2. Fix all infos, warnings issues and errors the commands surface

--- a/.cursor/rules/git-rules.mdc
+++ b/.cursor/rules/git-rules.mdc
@@ -16,7 +16,7 @@ Follow these rules closely when working with git and GitHub.
    - You can check for staged `.dart` files using this command:
 
      ```bash
-     git diff --name-only HEAD | grep '\.dart$'
+     git diff --name-only --staged HEAD | grep '\.dart$'
      ```
 
 2. Fix all infos, warnings issues and errors the commands surface

--- a/.cursor/rules/git-rules.mdc
+++ b/.cursor/rules/git-rules.mdc
@@ -12,7 +12,13 @@ Follow these rules closely when working with git and GitHub.
 
 ### Before committing
 
-1. Run `dart format` and `dart analyze`
+1. Run `dart format` and `dart analyze` if there are any `*.dart` files to be committed
+   - You can check for staged `.dart` files using this command:
+
+     ```bash
+     git diff --name-only HEAD | grep '\.dart$'
+     ```
+
 2. Fix all infos, warnings issues and errors the commands surface
 3. Repeat step 1. and 2. until all issues are resolved
 4. Stage any files that were changed in this process


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

Specify to only use format and analyze on dart files

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to clarify that formatting and analysis steps should only be run if there are staged Dart files.
  - Added a command snippet to help users check for staged Dart files before committing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->