### PR TITLE
docs: update Riverpod testing rules to use createContainer helper

### DIFF
--- a/.cursor/rules/testing-rules.mdc
+++ b/.cursor/rules/testing-rules.mdc
@@ -240,19 +240,23 @@ For overriding, we do `provider(parameter).overrideWith(...)`. The same goes for
 
 ## Unit Tests
 
+Use the `createContainer` helper method from `helpers/helpers.dart` to create a `ProviderContainer` for testing.
+The helper uses `ProviderContainer.test()` which automatically disposes the container when the test completes and disables retry behavior.
+
 ### Testing Riverpod value providers
 
 Create a helper method that reads and returns the value of the provider.  
 Example:
 
 ```dart
+import '../helpers/helpers.dart';
+
 String getUsername({required User user}) {
-  final container = ProviderContainer(
+  final container = createContainer(
     overrides: [
       userProvider.overrideWithValue(user),
     ],
   );
-  addTearDown(container.dispose);
   return container.read(usernameProvider);
 }
 
@@ -264,17 +268,18 @@ test('some test', () {
 
 ### Testing Riverpod future providers
 
-Create a helper method that reads and returns the value of the provider.  
+Create a helper method that reads and returns the future value of the provider.  
 Example:
 
 ```dart
+import '../helpers/helpers.dart';
+
 Future<String> getUsername({required User user}) async {
-  final container = ProviderContainer(
+  final container = createContainer(
     overrides: [
       userProvider.overrideWithValue(user),
     ],
   );
-  addTearDown(container.dispose);
   return container.read(usernameFutureProvider.future);
 }
 
@@ -286,29 +291,54 @@ test('some test', () async {
 
 ### Testing Riverpod notifier providers
 
-Create a helper method that reads and returns a subscription on the provider.  
+Create a helper method that listens to the provider and collects state changes.  
+Use `container.listen` with a states list to track async state transitions.  
 Example:
 
 ```dart
-ProviderSubscription<UsernameController> listenToController({required User user}) {
-  final container = ProviderContainer(
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../helpers/helpers.dart';
+
+late List<AsyncValue<String>> states;
+
+setUp(() {
+  states = [];
+});
+
+ProviderSubscription<AsyncValue<String>> listenToNotifier({required User user}) {
+  final container = createContainer(
     overrides: [
       userProvider.overrideWithValue(user),
     ],
   );
-  addTearDown(container.dispose);
-  return container.listen(usernameFutureProvider.notifier, (_, __) {});
+
+  return container.listen<AsyncValue<String>>(
+    usernameProvider,
+    (_, next) => states.add(next),
+    fireImmediately: true,
+  );
 }
 
-test('some test', () {
-  final subscription = listenToController(user: User());
-  expect(subscription.read().state.username, 'username');
-  fakeAsync((async) {
-    subscription.read().updateUsername('updated username');
-    async.flushMicrotasks();
-    expect(subscription.read().state.username, 'updated username');
-  });
+test('initial state is loading', () {
+  listenToNotifier(user: User());
+  expect(states, [const AsyncLoading<String>()]);
 });
+
+test(
+  'emits [loading, data] when build succeeds',
+  () => fakeAsync((async) {
+    listenToNotifier(user: User());
+    async.flushMicrotasks();
+
+    expect(states, [
+      isA<AsyncLoading<String>>(),
+      isA<AsyncData<String>>()
+          .having((d) => d.value, 'value', 'username'),
+    ]);
+  }),
+);
 ```
 
 ## Widget Tests


### PR DESCRIPTION
## Description

- update Riverpod unit testing examples to use the `createContainer` helper method
- document that `ProviderContainer.test()` automatically disposes containers and disables retry behavior
- improve notifier testing pattern to use `container.listen` with state collection

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Riverpod testing docs to use `createContainer` (via `ProviderContainer.test()`), and revises notifier examples to collect states with `container.listen`.
> 
> - **Docs (`.cursor/rules/testing-rules.mdc`)**
>   - **Unit tests**:
>     - Switch examples to `createContainer` from `helpers/helpers.dart`, leveraging `ProviderContainer.test()` (auto-dispose, retries disabled).
>     - Update value and future provider examples to read via `container.read(...)` without manual teardown.
>   - **Notifier testing**:
>     - Replace controller subscription pattern with `container.listen` on `usernameProvider` to capture `AsyncValue` state transitions.
>     - Add `fake_async` example asserting initial `loading` and subsequent `data` states.
>   - **Family providers**: Clarify overriding and reading/listening with parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35e0566aff76e853a81e9842ff023bfe3a15d850. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing rules and best practices for Riverpod tests, introducing a new container helper for improved test setup and teardown handling.
  * Refactored test helper signatures and patterns to use a unified listening approach for observing state changes across value, future, and notifier providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->