### PR TITLE
feat: add network retry with exponential backoff for riverpod providers

### DIFF
--- a/riverpod_app/lib/features/challenges/challenges_notifier.dart
+++ b/riverpod_app/lib/features/challenges/challenges_notifier.dart
@@ -3,10 +3,11 @@ import 'package:common/common.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:riverpod_app/data/repositories/challenges_repository.dart';
 import 'package:riverpod_app/data/repositories/concepts_repository.dart';
+import 'package:riverpod_app/utils/retry.dart';
 
 part 'challenges_notifier.g.dart';
 
-@riverpod
+@Riverpod(retry: networkRetry)
 class ChallengesNotifier extends _$ChallengesNotifier {
   @override
   Future<List<Challenge>> build(String conceptId) async {

--- a/riverpod_app/lib/features/challenges/challenges_notifier.g.dart
+++ b/riverpod_app/lib/features/challenges/challenges_notifier.g.dart
@@ -18,7 +18,7 @@ final class ChallengesNotifierProvider
       {required ChallengesNotifierFamily super.from,
       required String super.argument})
       : super(
-          retry: null,
+          retry: networkRetry,
           name: r'challengesProvider',
           isAutoDispose: true,
           dependencies: null,
@@ -51,7 +51,7 @@ final class ChallengesNotifierProvider
 }
 
 String _$challengesNotifierHash() =>
-    r'85ec3d6ae08c6488543e12562565466e855f402b';
+    r'8c144218b667eafc5edffe989a02274c2a548017';
 
 final class ChallengesNotifierFamily extends $Family
     with
@@ -59,7 +59,7 @@ final class ChallengesNotifierFamily extends $Family
             List<Challenge>, FutureOr<List<Challenge>>, String> {
   const ChallengesNotifierFamily._()
       : super(
-          retry: null,
+          retry: networkRetry,
           name: r'challengesProvider',
           dependencies: null,
           $allTransitiveDependencies: null,

--- a/riverpod_app/lib/features/concept/concept_notifier.dart
+++ b/riverpod_app/lib/features/concept/concept_notifier.dart
@@ -1,10 +1,11 @@
 import 'package:common/common.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:riverpod_app/data/repositories/concepts_repository.dart';
+import 'package:riverpod_app/utils/retry.dart';
 
 part 'concept_notifier.g.dart';
 
-@riverpod
+@Riverpod(retry: networkRetry)
 class ConceptNotifier extends _$ConceptNotifier {
   @override
   Future<Concept> build(String id) async {

--- a/riverpod_app/lib/features/concept/concept_notifier.g.dart
+++ b/riverpod_app/lib/features/concept/concept_notifier.g.dart
@@ -18,7 +18,7 @@ final class ConceptNotifierProvider
       {required ConceptNotifierFamily super.from,
       required String super.argument})
       : super(
-          retry: null,
+          retry: networkRetry,
           name: r'conceptProvider',
           isAutoDispose: true,
           dependencies: null,
@@ -50,7 +50,7 @@ final class ConceptNotifierProvider
   }
 }
 
-String _$conceptNotifierHash() => r'28f14a871e6e434ee6a125ccb3a0f274c8b63594';
+String _$conceptNotifierHash() => r'c872fa91910e083d9c09baf9e91e88865ce5d94b';
 
 final class ConceptNotifierFamily extends $Family
     with
@@ -58,7 +58,7 @@ final class ConceptNotifierFamily extends $Family
             FutureOr<Concept>, String> {
   const ConceptNotifierFamily._()
       : super(
-          retry: null,
+          retry: networkRetry,
           name: r'conceptProvider',
           dependencies: null,
           $allTransitiveDependencies: null,

--- a/riverpod_app/lib/features/concepts/concepts_notifier.dart
+++ b/riverpod_app/lib/features/concepts/concepts_notifier.dart
@@ -1,10 +1,11 @@
 import 'package:common/common.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:riverpod_app/data/repositories/concepts_repository.dart';
+import 'package:riverpod_app/utils/retry.dart';
 
 part 'concepts_notifier.g.dart';
 
-@riverpod
+@Riverpod(retry: networkRetry)
 class ConceptsNotifier extends _$ConceptsNotifier {
   @override
   Future<List<Concept>> build() async {

--- a/riverpod_app/lib/features/concepts/concepts_notifier.g.dart
+++ b/riverpod_app/lib/features/concepts/concepts_notifier.g.dart
@@ -18,7 +18,7 @@ final class ConceptsNotifierProvider
       : super(
           from: null,
           argument: null,
-          retry: null,
+          retry: networkRetry,
           name: r'conceptsProvider',
           isAutoDispose: true,
           dependencies: null,
@@ -33,7 +33,7 @@ final class ConceptsNotifierProvider
   ConceptsNotifier create() => ConceptsNotifier();
 }
 
-String _$conceptsNotifierHash() => r'7fa6554adde9f1a13dfe6396b4d06de247eddf7c';
+String _$conceptsNotifierHash() => r'43ac5d7c9702cc25e030ddb8e505ac56ed36faca';
 
 abstract class _$ConceptsNotifier extends $AsyncNotifier<List<Concept>> {
   FutureOr<List<Concept>> build();

--- a/riverpod_app/lib/utils/retry.dart
+++ b/riverpod_app/lib/utils/retry.dart
@@ -1,0 +1,60 @@
+import 'package:dio/dio.dart';
+
+/// Maximum number of retry attempts before giving up.
+const int maxRetryAttempts = 5;
+
+/// Base delay in milliseconds for exponential backoff.
+const int baseDelayMs = 200;
+
+/// Retry function with exponential backoff for network-related errors.
+///
+/// Returns a [Duration] to wait before the next retry, or `null` to stop
+/// retrying.
+///
+/// This function implements exponential backoff starting at [baseDelayMs]
+/// and doubling with each attempt.
+///
+/// Retries are only performed for transient network errors that may succeed
+/// on retry. Non-retryable errors (e.g., 4xx client errors, validation errors)
+/// return `null` immediately to prevent unnecessary retries.
+Duration? networkRetry(int retryCount, Object error) {
+  if (retryCount >= maxRetryAttempts) return null;
+
+  if (!_isRetryableError(error)) return null;
+
+  return Duration(milliseconds: baseDelayMs * (1 << retryCount));
+}
+
+/// Determines whether an error is retryable.
+///
+/// Returns `true` for transient network errors that may succeed on retry:
+/// - Connection timeouts
+/// - Send/receive timeouts
+/// - Connection errors (no internet, DNS failures, etc.)
+/// - Server errors (5xx status codes)
+///
+/// Returns `false` for non-retryable errors:
+/// - Client errors (4xx status codes)
+/// - Request cancellation
+/// - Bad responses that indicate invalid requests
+/// - Non-DioException errors (e.g., parsing errors, business logic errors)
+bool _isRetryableError(Object error) {
+  if (error is! DioException) return false;
+
+  switch (error.type) {
+    case DioExceptionType.connectionTimeout:
+    case DioExceptionType.sendTimeout:
+    case DioExceptionType.receiveTimeout:
+    case DioExceptionType.connectionError:
+      return true;
+    case DioExceptionType.badResponse:
+      final statusCode = error.response?.statusCode;
+      if (statusCode == null) return false;
+      // Only retry server errors (5xx), not client errors (4xx)
+      return statusCode >= 500 && statusCode < 600;
+    case DioExceptionType.cancel:
+    case DioExceptionType.badCertificate:
+    case DioExceptionType.unknown:
+      return false;
+  }
+}

--- a/riverpod_app/test/utils/retry_test.dart
+++ b/riverpod_app/test/utils/retry_test.dart
@@ -1,0 +1,160 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_app/utils/retry.dart';
+
+void main() {
+  group('networkRetry', () {
+    group('retry attempts', () {
+      test('returns exponentially increasing durations', () {
+        final error = DioException(
+          type: DioExceptionType.connectionTimeout,
+          requestOptions: RequestOptions(),
+        );
+
+        final expectedDurations = {
+          0: const Duration(milliseconds: 200),
+          1: const Duration(milliseconds: 400),
+          2: const Duration(milliseconds: 800),
+          3: const Duration(milliseconds: 1600),
+          4: const Duration(milliseconds: 3200),
+        };
+
+        for (final entry in expectedDurations.entries) {
+          expect(
+            networkRetry(entry.key, error),
+            entry.value,
+            reason: 'retry count ${entry.key}',
+          );
+        }
+      });
+
+      test('returns null when max retry attempts reached or exceeded', () {
+        final error = DioException(
+          type: DioExceptionType.connectionTimeout,
+          requestOptions: RequestOptions(),
+        );
+
+        for (final retryCount in [5, 10, 100]) {
+          expect(
+            networkRetry(retryCount, error),
+            isNull,
+            reason: 'retry count $retryCount',
+          );
+        }
+      });
+    });
+
+    group('retryable errors', () {
+      test('retries on transient DioException types', () {
+        final retryableTypes = [
+          DioExceptionType.connectionTimeout,
+          DioExceptionType.sendTimeout,
+          DioExceptionType.receiveTimeout,
+          DioExceptionType.connectionError,
+        ];
+
+        for (final type in retryableTypes) {
+          final result = networkRetry(
+            0,
+            DioException(type: type, requestOptions: RequestOptions()),
+          );
+          expect(result, isNotNull, reason: type.name);
+        }
+      });
+
+      test('retries on server errors (5xx)', () {
+        final serverErrorCodes = [500, 502, 503, 504];
+
+        for (final statusCode in serverErrorCodes) {
+          final result = networkRetry(
+            0,
+            DioException(
+              type: DioExceptionType.badResponse,
+              response: Response(
+                statusCode: statusCode,
+                requestOptions: RequestOptions(),
+              ),
+              requestOptions: RequestOptions(),
+            ),
+          );
+          expect(result, isNotNull, reason: 'status code $statusCode');
+        }
+      });
+    });
+
+    group('non-retryable errors', () {
+      test('does not retry on client errors (4xx)', () {
+        final clientErrorCodes = [400, 401, 403, 404, 422];
+
+        for (final statusCode in clientErrorCodes) {
+          final result = networkRetry(
+            0,
+            DioException(
+              type: DioExceptionType.badResponse,
+              response: Response(
+                statusCode: statusCode,
+                requestOptions: RequestOptions(),
+              ),
+              requestOptions: RequestOptions(),
+            ),
+          );
+          expect(result, isNull, reason: 'status code $statusCode');
+        }
+      });
+
+      test('does not retry on non-transient DioException types', () {
+        final nonRetryableTypes = [
+          DioExceptionType.cancel,
+          DioExceptionType.badCertificate,
+          DioExceptionType.unknown,
+        ];
+
+        for (final type in nonRetryableTypes) {
+          final result = networkRetry(
+            0,
+            DioException(type: type, requestOptions: RequestOptions()),
+          );
+          expect(result, isNull, reason: type.name);
+        }
+      });
+
+      test('does not retry on non-DioException errors', () {
+        final nonDioErrors = [
+          Exception('some error'),
+          const FormatException('parse error'),
+          StateError('state error'),
+          TypeError(),
+        ];
+
+        for (final error in nonDioErrors) {
+          final result = networkRetry(0, error);
+          expect(result, isNull, reason: error.runtimeType.toString());
+        }
+      });
+
+      test('does not retry on badResponse with missing status code', () {
+        final edgeCases = [
+          DioException(
+            type: DioExceptionType.badResponse,
+            response: Response(requestOptions: RequestOptions()),
+            requestOptions: RequestOptions(),
+          ),
+          DioException(
+            type: DioExceptionType.badResponse,
+            requestOptions: RequestOptions(),
+          ),
+        ];
+
+        for (final error in edgeCases) {
+          final result = networkRetry(0, error);
+          expect(
+            result,
+            isNull,
+            reason:
+                error.response == null ? 'null response' : 'null statusCode',
+          );
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

- Add `networkRetry` utility function implementing exponential backoff for transient network errors
- Integrate retry logic with `ChallengesNotifier`, `ConceptNotifier`, and `ConceptsNotifier` providers
- Retry only on transient errors: connection timeouts, send/receive timeouts, connection errors, and 5xx server errors
- Skip retry for non-recoverable errors: 4xx client errors, request cancellation, bad certificates
- Add comprehensive unit tests for the retry utility

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `networkRetry` with exponential backoff and applies it to `ChallengesNotifier`, `ConceptNotifier`, and `ConceptsNotifier`, plus comprehensive tests.
> 
> - **Utility**:
>   - Add `utils/retry.dart` with `networkRetry` implementing exponential backoff, retry limits, and retryable error filtering (timeouts, connection errors, 5xx).
> - **Providers**:
>   - Annotate `ChallengesNotifier`, `ConceptNotifier`, and `ConceptsNotifier` with `@Riverpod(retry: networkRetry)`; generated provider code sets `retry: networkRetry`.
> - **Tests**:
>   - Add `test/utils/retry_test.dart` validating backoff timings, max attempts, retryable vs non-retryable errors, and edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0895d0211269373381e39bede48791a951e68f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic network retry mechanism with exponential backoff for improved reliability when requests encounter timeouts, connection errors, or temporary server issues.

* **Tests**
  * Added comprehensive test coverage for network retry behavior and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->