### PR TITLE
docs: update README with ChallengeProgressNotifier and add Riverpod launch configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,32 @@
       "type": "dart",
       "program": "bloc_app/lib/main_production.dart",
       "args": ["--flavor", "production", "--target", "lib/main_production.dart"]
+    },
+    {
+      "name": "Launch Riverpod App development",
+      "request": "launch",
+      "type": "dart",
+      "program": "riverpod_app/lib/main_development.dart",
+      "args": [
+        "--flavor",
+        "development",
+        "--target",
+        "lib/main_development.dart"
+      ]
+    },
+    {
+      "name": "Launch Riverpod App staging",
+      "request": "launch",
+      "type": "dart",
+      "program": "riverpod_app/lib/main_staging.dart",
+      "args": ["--flavor", "staging", "--target", "lib/main_staging.dart"]
+    },
+    {
+      "name": "Launch Riverpod App production",
+      "request": "launch",
+      "type": "dart",
+      "program": "riverpod_app/lib/main_production.dart",
+      "args": ["--flavor", "production", "--target", "lib/main_production.dart"]
     }
   ]
 }

--- a/riverpod_app/README.md
+++ b/riverpod_app/README.md
@@ -17,6 +17,9 @@ The domain model is defined in the `lib/domain` folder based on the following da
 - `concept`: Displays the sections of a concept.
 - `challenges`: Displays the list of challenges for a concept.
 
+### Notifiers
+- `ChallengeProgressNotifier`: Manages the user's progress on a specific challenge, including answer selection, submission, and reset functionality. This demonstrates testing a Riverpod Notifier with mutable state and multiple methods that modify state imperatively. See [`challenge_progress_notifier_test.dart`](test/features/challenges/challenge_progress_notifier_test.dart) for the corresponding tests.
+
 ## Core Packages
 - `flutter_riverpod`: Used for state management.
 - `retrofit` and `dio`: Used for the API client.


### PR DESCRIPTION
## Description

- Document the new `ChallengeProgressNotifier` in the riverpod_app README, including a link to its test file
- Add VS Code launch configurations for the Riverpod app (development, staging, production flavors)

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents `ChallengeProgressNotifier` in the Riverpod README and adds VS Code launch configs for Riverpod app flavors.
> 
> - **Documentation**:
>   - Add Notifiers section in `riverpod_app/README.md` describing `ChallengeProgressNotifier` with link to its test.
> - **Tooling**:
>   - Add VS Code launch configurations in `.vscode/launch.json` for Riverpod app `development`, `staging`, and `production` flavors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46f12d6567c515604788f4082e4d7acbd46659f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with details about progress management functionality.

* **Chores**
  * Added launch configurations for development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->