### PR TITLE
ci: add if_not_found success to codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,10 +11,12 @@ coverage:
       default:
         target: auto
         base: auto
+        if_not_found: success
     patch:
       default:
         target: auto
         base: auto
+        if_not_found: success
 
 flags:
   riverpod_app:
@@ -50,6 +52,8 @@ component_management:
       - type: project
         target: auto
         base: auto
+        if_not_found: success
       - type: patch
         target: auto
         base: auto
+        if_not_found: success


### PR DESCRIPTION
## Description

- add `if_not_found: success` to codecov configuration for default, patch, and component coverage settings
- prevents codecov from failing when coverage data is not found

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configure Codecov to succeed when coverage data is missing for project, patch, and component statuses.
> 
> - **CI/Codecov config** (`codecov.yml`):
>   - Add `if_not_found: success` to `coverage.status.project.default` and `coverage.status.patch.default`.
>   - Add `if_not_found: success` to `component_management.default_rules.statuses` for both `project` and `patch`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bda103a2e902e94453d6cc0cd83af0ff8abff92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline reliability by configuring fallback behavior for coverage and component management checks to ensure builds proceed successfully when coverage metrics are unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->