### PR TITLE
test: add challenges robot and progress flow integration test

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,7 @@ ignore:
   - "**/*.json"
   - ".gitignore"
   - ".gitattributes"
+  - "**/integration_test/**/*"
 
 coverage:
   status:

--- a/riverpod_app/integration_test/app_test.dart
+++ b/riverpod_app/integration_test/app_test.dart
@@ -1,17 +1,13 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:riverpod_app/app/view/app.dart';
 import 'package:riverpod_app/data/services/cache_manager_provider.dart';
 import 'package:riverpod_app/features/challenges/view/challenges_view.dart';
-import 'package:riverpod_app/features/challenges/view/widgets/challenges_list.dart';
 import 'package:riverpod_app/features/concept/view/concept_view.dart';
-import 'package:riverpod_app/features/concept/view/widgets/sections_view.dart';
 import 'package:riverpod_app/features/concepts/view/concepts_view.dart';
 
+import './challenges_robot.dart';
 import './mocks.mocks.dart';
 
 void main() {
@@ -32,36 +28,59 @@ void main() {
 
   group('App Integration Test', () {
     testWidgets('Concept flow', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            cacheManagerProvider.overrideWithValue(cacheManager),
-          ],
-          child: const App(),
-        ),
+      final robot = ChallengesRobot(
+        tester,
+        overrides: [cacheManagerProvider.overrideWithValue(cacheManager)],
       );
-      await tester.pumpAndSettle();
+      await robot.pumpApp();
 
       expect(find.byType(ConceptsView), findsOneWidget);
 
-      await tester.tap(find.byType(ListTile).first);
-      await tester.pumpAndSettle();
+      await robot.tapFirstConcept();
 
       expect(find.byType(ConceptView), findsOneWidget);
 
-      await tester.tap(find.byKey(SectionsView.forwardButtonKey));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(SectionsView.forwardButtonKey));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(SectionsView.forwardButtonKey));
-      await tester.pumpAndSettle();
+      await robot.navigateThroughSectionsToChallenges();
 
       expect(find.byType(ChallengesView), findsOneWidget);
 
-      await tester.tap(find.byKey(ChallengesList.doneButtonKey));
-      await tester.pumpAndSettle();
+      await robot.tapDoneButton();
 
       expect(find.byType(ConceptsView), findsOneWidget);
+    });
+
+    testWidgets('Challenge progress flow', (WidgetTester tester) async {
+      final robot = ChallengesRobot(
+        tester,
+        overrides: [cacheManagerProvider.overrideWithValue(cacheManager)],
+      );
+      await robot.pumpApp();
+      await robot.tapFirstConcept();
+      await robot.navigateThroughSectionsToChallenges();
+
+      expect(find.byType(ChallengesView), findsOneWidget);
+      expect(robot.isSubmitButtonEnabled, isFalse);
+
+      await robot.tapAnswerOption('Option 2 EN');
+
+      expect(robot.isSubmitButtonEnabled, isTrue);
+
+      await robot.tapSubmitButton();
+
+      expect(robot.findIncorrectText, findsOneWidget);
+      expect(robot.findResetButton, findsOneWidget);
+
+      await robot.tapResetButton();
+
+      expect(robot.findIncorrectText, findsNothing);
+      expect(robot.findSubmitButton, findsOneWidget);
+
+      await robot.tapAnswerOption('Option 1 EN');
+      await robot.tapAnswerOption('Option 2 EN');
+      await robot.tapAnswerOption('Option 3 EN');
+      await robot.tapSubmitButton();
+
+      expect(robot.findCorrectText, findsOneWidget);
     });
   });
 }

--- a/riverpod_app/integration_test/challenges_robot.dart
+++ b/riverpod_app/integration_test/challenges_robot.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:riverpod_app/app/view/app.dart';
+import 'package:riverpod_app/features/challenges/view/widgets/challenge_card.dart';
+import 'package:riverpod_app/features/challenges/view/widgets/challenges_list.dart';
+import 'package:riverpod_app/features/concept/view/widgets/sections_view.dart';
+
+class ChallengesRobot {
+  ChallengesRobot(this.tester, {this.overrides = const []});
+
+  final WidgetTester tester;
+  final List<Override> overrides;
+
+  Finder get _firstChallengeCard => find.byType(ChallengeCard).first;
+
+  Finder _findInFirstCard(Finder matching) => find.descendant(
+        of: _firstChallengeCard,
+        matching: matching,
+      );
+
+  Finder get findSubmitButton =>
+      _findInFirstCard(find.byKey(ChallengeCard.submitButtonKey));
+
+  Finder get findResetButton =>
+      _findInFirstCard(find.byKey(ChallengeCard.resetButtonKey));
+
+  Finder get findCorrectText => _findInFirstCard(find.text('Correct!'));
+
+  Finder get findIncorrectText => _findInFirstCard(find.text('Incorrect'));
+
+  bool get isSubmitButtonEnabled {
+    final button = tester.widget<FilledButton>(findSubmitButton);
+    return button.onPressed != null;
+  }
+
+  Future<void> pumpApp() async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: overrides,
+        child: const App(),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapFirstConcept() async {
+    await tester.tap(find.byType(ListTile).first);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> navigateThroughSectionsToChallenges() async {
+    await tester.tap(find.byKey(SectionsView.forwardButtonKey));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(SectionsView.forwardButtonKey));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(SectionsView.forwardButtonKey));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapDoneButton() async {
+    await tester.tap(find.byKey(ChallengesList.doneButtonKey));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapAnswerOption(String optionText) async {
+    await tester.tap(_findInFirstCard(find.text(optionText)));
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapSubmitButton() async {
+    await tester.tap(findSubmitButton);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapResetButton() async {
+    await tester.tap(findResetButton);
+    await tester.pumpAndSettle();
+  }
+}

--- a/riverpod_app/integration_test/challenges_robot.dart
+++ b/riverpod_app/integration_test/challenges_robot.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:riverpod_app/app/view/app.dart';
 import 'package:riverpod_app/features/challenges/view/widgets/challenge_card.dart';
 import 'package:riverpod_app/features/challenges/view/widgets/challenges_list.dart';


### PR DESCRIPTION
## Description

- Introduce `ChallengesRobot` class using the robot pattern for cleaner integration tests
- Refactor existing concept flow test to use the new robot
- Add new challenge progress flow test covering:
  - Answer selection and submit button enabled state
  - Incorrect answer submission and reset functionality
  - Correct answer submission flow

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Integration tests refactor and additions**
> 
> - Add `integration_test/challenges_robot.dart` implementing a robot pattern for reusable challenge interactions (pump app, navigate, select answers, submit/reset)
> - Refactor `integration_test/app_test.dart` to use `ChallengesRobot` for the Concept flow
> - Add new "Challenge progress flow" test covering submit button enablement, incorrect/correct answers, and reset behavior
> 
> **Coverage config**
> 
> - Update `codecov.yml` to ignore `**/integration_test/**/*` from coverage
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe66d8708a7a30d3704ab5df0ffe28e27163a8e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a reusable test helper to drive challenge flows and replaced manual UI steps with robot-driven interactions; added an end-to-end "challenge progress" integration test covering navigation, answering, submission, reset, and result assertions.
* **Chores**
  * Excluded integration tests from coverage reporting to keep metrics focused on unit/tested code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->