### PR TITLE
ci: centralize empty codecov upload in check-build-results job

### DIFF
--- a/.github/actions/build-flutter-package/action.yaml
+++ b/.github/actions/build-flutter-package/action.yaml
@@ -5,31 +5,21 @@ inputs:
   working-directory:
     description: 'Working directory of the Flutter package'
     required: true
-  codecov-token:
-    description: 'Codecov token for uploading results (optional for public repos)'
-    required: false
-  skip-tests:
-    description: 'Skip running tests and perform an empty codecov upload instead'
-    required: false
-    default: 'false'
 
 runs:
   using: 'composite'
   steps:
     - name: Setup Flutter package
-      if: ${{ inputs.skip-tests != 'true' }}
       uses: ./.github/actions/setup-flutter-package
       with:
         working-directory: ${{ inputs.working-directory }}
 
     - name: Check Flutter package
-      if: ${{ inputs.skip-tests != 'true' }}
       uses: ./.github/actions/check-flutter-package
       with:
         working-directory: ${{ inputs.working-directory }}
 
     - name: Run tests
-      if: ${{ inputs.skip-tests != 'true' }}
       id: tests
       uses: ./.github/actions/run-tests
       with:
@@ -39,8 +29,6 @@ runs:
       if: ${{ !cancelled() }}
       uses: ./.github/actions/upload-test-results
       with:
-        token: ${{ inputs.codecov-token }}
         package-name: ${{ inputs.working-directory }}
         coverage-files: ${{ steps.tests.outputs.coverage-file }}
         test-results-files: ${{ steps.tests.outputs.test-results-file }}
-        empty-upload: ${{ inputs.skip-tests }}

--- a/.github/actions/upload-test-results/action.yaml
+++ b/.github/actions/upload-test-results/action.yaml
@@ -2,9 +2,6 @@ name: Upload Code Coverage and Test Results to Codecov
 description: Uploads code coverage and test results to Codecov
 
 inputs:
-  token:
-    description: 'Codecov token'
-    required: false
   package-name:
     description: 'Flutter app/package name'
     required: true
@@ -14,20 +11,14 @@ inputs:
   test-results-files:
     description: 'Comma separated list of paths to the test results files'
     required: false
-  empty-upload:
-    description: 'Skip uploading reports and mark codecov checks as passed when there are no code changes that would trigger tests'
-    required: false
-    default: 'false'
 
 runs:
   using: 'composite'
 
   steps:
     - name: Upload coverage report to Codecov
-      if: ${{ inputs.empty-upload != 'true' }}
       uses: codecov/codecov-action@v5
       with:
-        token: ${{ inputs.token }}
         files: ${{ inputs.coverage-files }}
         disable_search: true
         name: ${{ inputs.package-name }}-coverage
@@ -36,20 +27,11 @@ runs:
         report_type: coverage
 
     - name: Upload test results to Codecov
-      if: ${{ inputs.empty-upload != 'true' }}
       uses: codecov/codecov-action@v5
       with:
-        token: ${{ inputs.token }}
         files: ${{ inputs.test-results-files }}
         disable_search: true
         name: ${{ inputs.package-name }}-tests
         flags: ${{ inputs.package-name }}
         fail_ci_if_error: true
         report_type: test_results
-
-    - name: Empty upload to pass codecov checks
-      if: ${{ inputs.empty-upload == 'true' }}
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ inputs.token }}
-        run_command: empty-upload

--- a/.github/workflows/ci-packages.yaml
+++ b/.github/workflows/ci-packages.yaml
@@ -14,11 +14,10 @@ jobs:
   check-changed-files:
     runs-on: ubuntu-latest
     outputs:
-      riverpod_app_changed: ${{ steps.changed-files.outputs.riverpod_app_any_modified }}
-      bloc_app_changed: ${{ steps.changed-files.outputs.bloc_app_any_modified }}
-      common_changed: ${{ steps.changed-files.outputs.common_any_modified }}
-      common_app_files_changed: ${{ steps.changed-files.outputs.common_app_files_any_modified }}
-      common_files_changed: ${{ steps.changed-files.outputs.common_files_any_modified }}
+      should-build-riverpod-app: ${{ steps.determine-builds.outputs.should-build-riverpod-app }}
+      should-build-bloc-app: ${{ steps.determine-builds.outputs.should-build-bloc-app }}
+      should-build-common: ${{ steps.determine-builds.outputs.should-build-common }}
+      any-tests-to-run: ${{ steps.determine-builds.outputs.any-tests-to-run }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,9 +45,44 @@ jobs:
               - '.github/actions/upload-test-results/action.yaml'
             common:
               - 'common/**'
+      - name: Determine which packages to build
+        id: determine-builds
+        run: |
+          RIVERPOD_APP="${{ steps.changed-files.outputs.riverpod_app_any_modified }}"
+          BLOC_APP="${{ steps.changed-files.outputs.bloc_app_any_modified }}"
+          COMMON="${{ steps.changed-files.outputs.common_any_modified }}"
+          COMMON_APP_FILES="${{ steps.changed-files.outputs.common_app_files_any_modified }}"
+          COMMON_FILES="${{ steps.changed-files.outputs.common_files_any_modified }}"
+
+          # Determine if each package should be built
+          if [[ "$RIVERPOD_APP" == "true" || "$COMMON_APP_FILES" == "true" || "$COMMON_FILES" == "true" || "$COMMON" == "true" ]]; then
+            echo "should-build-riverpod-app=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-build-riverpod-app=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$BLOC_APP" == "true" || "$COMMON_APP_FILES" == "true" || "$COMMON_FILES" == "true" || "$COMMON" == "true" ]]; then
+            echo "should-build-bloc-app=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-build-bloc-app=false" >> $GITHUB_OUTPUT
+          fi
+
+          if [[ "$COMMON" == "true" || "$COMMON_FILES" == "true" ]]; then
+            echo "should-build-common=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-build-common=false" >> $GITHUB_OUTPUT
+          fi
+
+          # Determine if any tests will run
+          if [[ "$RIVERPOD_APP" == "true" || "$BLOC_APP" == "true" || "$COMMON" == "true" || "$COMMON_APP_FILES" == "true" || "$COMMON_FILES" == "true" ]]; then
+            echo "any-tests-to-run=true" >> $GITHUB_OUTPUT
+          else
+            echo "any-tests-to-run=false" >> $GITHUB_OUTPUT
+          fi
 
   build-riverpod-app:
     needs: check-changed-files
+    if: ${{ needs.check-changed-files.outputs.should-build-riverpod-app == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -56,10 +90,10 @@ jobs:
         uses: ./.github/actions/build-flutter-package
         with:
           working-directory: riverpod_app
-          skip-tests: ${{ needs.check-changed-files.outputs.riverpod_app_changed != 'true' && needs.check-changed-files.outputs.common_app_files_changed != 'true' && needs.check-changed-files.outputs.common_files_changed != 'true' && needs.check-changed-files.outputs.common_changed != 'true' }}
 
   build-bloc-app:
     needs: check-changed-files
+    if: ${{ needs.check-changed-files.outputs.should-build-bloc-app == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -67,10 +101,10 @@ jobs:
         uses: ./.github/actions/build-flutter-package
         with:
           working-directory: bloc_app
-          skip-tests: ${{ needs.check-changed-files.outputs.bloc_app_changed != 'true' && needs.check-changed-files.outputs.common_app_files_changed != 'true' && needs.check-changed-files.outputs.common_files_changed != 'true' && needs.check-changed-files.outputs.common_changed != 'true' }}
 
   build-common:
     needs: check-changed-files
+    if: ${{ needs.check-changed-files.outputs.should-build-common == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -78,12 +112,11 @@ jobs:
         uses: ./.github/actions/build-flutter-package
         with:
           working-directory: common
-          skip-tests: ${{ needs.check-changed-files.outputs.common_changed != 'true' && needs.check-changed-files.outputs.common_files_changed != 'true' }}
 
   check-build-results:
     runs-on: ubuntu-latest
-    needs: [build-riverpod-app, build-bloc-app, build-common]
-    # Always run this job, even if dependencies fail
+    needs: [check-changed-files, build-riverpod-app, build-bloc-app, build-common]
+    # Always run this job, even if dependencies are skipped or fail
     if: ${{ !cancelled() }}
     steps:
       - name: Check build job results
@@ -97,3 +130,8 @@ jobs:
           else
             echo "All build jobs passed."
           fi
+      - name: Empty upload to pass codecov checks
+        if: ${{ needs.check-changed-files.outputs.any-tests-to-run == 'false' }}
+        uses: codecov/codecov-action@v5
+        with:
+          run_command: empty-upload


### PR DESCRIPTION
## Description

- Centralize empty codecov upload to only run once in check-build-results job when no tests were triggered
- Move verbose build conditions to check-changed-files job with `should-build-*` outputs for cleaner job definitions
- Remove `skip-tests` and `empty-upload` logic from individual package actions
- Remove codecov token input since it's not needed for open source projects

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD pipeline configuration by removing optional test-skip inputs and conditional test execution logic.
  * Consolidated build determination logic for improved consistency.
  * Streamlined test result and coverage upload processes to always execute.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->