### PR TITLE
test: add syntax error to test CI pipeline validation

### DIFF
--- a/common/lib/src/typedefs.dart
+++ b/common/lib/src/typedefs.dart
@@ -1,2 +1,5 @@
 /// A map of language codes to localized strings.
 typedef Localizations = Map<String, String>;
+
+/// This is a syntax error for CI testing
+const syntaxError = // missing value intentionally


### PR DESCRIPTION
## Description

- Add intentional syntax error to `common/lib/src/typedefs.dart`
- This PR is meant to fail CI to verify the pipeline correctly catches syntax errors

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore